### PR TITLE
Handle JSON decode errors in Intervals request

### DIFF
--- a/src/intervals_mcp_server/server.py
+++ b/src/intervals_mcp_server/server.py
@@ -91,8 +91,8 @@ async def make_intervals_request(
 
             try:
                 return response.json()
-            except JSONDecodeError as e:
-                logger.error("JSON decode error: %s", str(e))
+            except (JSONDecodeError, ValueError) as e:
+                logger.error("JSON parsing error: %s", str(e))
                 return {
                     "error": True,
                     "message": f"Invalid JSON in response: {str(e)}",

--- a/src/intervals_mcp_server/server.py
+++ b/src/intervals_mcp_server/server.py
@@ -17,6 +17,7 @@ The server follows MCP specifications and uses the Python MCP SDK.
 The server is designed to be run as a standalone script.
 """
 
+from json import JSONDecodeError
 import logging
 import os
 from datetime import datetime, timedelta
@@ -84,7 +85,18 @@ async def make_intervals_request(
 
             # Assign to _ to indicate intentional ignoring of return value
             _ = response.raise_for_status()
-            return response.json() if response.content else {}
+
+            if not response.content:
+                return {}
+
+            try:
+                return response.json()
+            except JSONDecodeError as e:
+                logger.error("JSON decode error: %s", str(e))
+                return {
+                    "error": True,
+                    "message": f"Invalid JSON in response: {str(e)}",
+                }
 
         except httpx.HTTPStatusError as e:
             error_code = e.response.status_code

--- a/tests/test_make_intervals_request.py
+++ b/tests/test_make_intervals_request.py
@@ -1,0 +1,43 @@
+import asyncio
+import logging
+
+import httpx
+
+from intervals_mcp_server.server import make_intervals_request
+
+
+class MockBadJSONResponse:
+    def __init__(self):
+        self.content = b"bad"
+        self.status_code = 200
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        raise ValueError("No JSON")
+
+
+class MockAsyncClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def get(self, *args, **kwargs):
+        return MockBadJSONResponse()
+
+
+def test_make_intervals_request_bad_json(monkeypatch, caplog):
+    monkeypatch.setattr(httpx, "AsyncClient", MockAsyncClient)
+
+    with caplog.at_level(logging.ERROR):
+        result = asyncio.run(make_intervals_request("/bad"))
+
+    assert result["error"] is True
+    assert "Invalid JSON in response" in result["message"]
+    assert "JSON decode error" in caplog.text


### PR DESCRIPTION
## Summary
- handle bad JSON from Intervals API
- test JSON decode error handling

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*