### PR TITLE
Add unit tests and pytest configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,17 @@ keywords = ["intervals", "cycling", "running", "mcp", "ai"]
 "Bug Tracker" = "https://github.com/mvilanova/intervals-mcp-server/issues"
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0.0", "mypy>=1.0.0", "ruff>=0.1.0"]
+dev = ["pytest>=7.0.0", "mypy>=1.0.0", "ruff>=0.1.0", "pytest-asyncio>=0.21"]
 
 [tool.hatch.build]
 include = ["server.py", "utils/*.py", "README.md", ".env.example"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/intervals_mcp_server"]
+
+[tool.hatch.envs.default.scripts]
+test = "pytest -q"
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,116 @@
+from intervals_mcp_server.utils.formatting import (
+    format_activity_summary,
+    format_workout,
+    format_wellness_entry,
+    format_event_summary,
+    format_event_details,
+    format_intervals,
+)
+
+
+def test_format_activity_summary():
+    data = {
+        "name": "Morning Ride",
+        "id": 1,
+        "type": "Ride",
+        "startTime": "2024-01-01T08:00:00Z",
+        "distance": 1000,
+        "duration": 3600,
+    }
+    result = format_activity_summary(data)
+    assert "Activity: Morning Ride" in result
+    assert "ID: 1" in result
+
+
+def test_format_workout():
+    workout = {
+        "name": "Workout1",
+        "description": "desc",
+        "sport": "Ride",
+        "duration": 3600,
+        "tss": 50,
+        "intervals": [1, 2, 3],
+    }
+    result = format_workout(workout)
+    assert "Workout: Workout1" in result
+    assert "Intervals: 3" in result
+
+
+def test_format_wellness_entry():
+    entry = {
+        "date": "2024-01-01",
+        "ctl": 70,
+        "sleepSecs": 28800,
+        "weight": 70,
+    }
+    result = format_wellness_entry(entry)
+    assert "Date: 2024-01-01" in result
+    assert "Fitness (CTL): 70" in result
+
+
+def test_format_event_summary():
+    event = {
+        "date": "2024-01-01",
+        "id": "e1",
+        "name": "Event1",
+        "description": "desc",
+        "race": True,
+    }
+    summary = format_event_summary(event)
+    assert "Date: 2024-01-01" in summary
+    assert "Type: Race" in summary
+
+
+def test_format_event_details():
+    event = {
+        "id": "e1",
+        "date": "2024-01-01",
+        "name": "Event1",
+        "description": "desc",
+        "workout": {
+            "id": "w1",
+            "sport": "Ride",
+            "duration": 3600,
+            "tss": 50,
+            "intervals": [1, 2],
+        },
+        "race": True,
+        "priority": "A",
+        "result": "1st",
+        "calendar": {"name": "Main"},
+    }
+    details = format_event_details(event)
+    assert "Event Details:" in details
+    assert "Workout Information:" in details
+
+
+def test_format_intervals():
+    intervals_data = {
+        "id": "i1",
+        "analyzed": True,
+        "icu_intervals": [
+            {
+                "type": "work",
+                "label": "Rep 1",
+                "elapsed_time": 60,
+                "moving_time": 60,
+                "distance": 100,
+                "average_watts": 200,
+                "max_watts": 300,
+                "average_watts_kg": 3.0,
+                "max_watts_kg": 5.0,
+                "weighted_average_watts": 220,
+                "intensity": 0.8,
+                "training_load": 10,
+                "average_heartrate": 150,
+                "max_heartrate": 160,
+                "average_cadence": 90,
+                "max_cadence": 100,
+                "average_speed": 6,
+                "max_speed": 8,
+            }
+        ],
+    }
+    result = format_intervals(intervals_data)
+    assert "Intervals Analysis:" in result
+    assert "Rep 1" in result

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -49,7 +49,7 @@ def test_get_activity_details(monkeypatch):
         return sample
 
     monkeypatch.setattr("intervals_mcp_server.server.make_intervals_request", fake_request)
-    result = asyncio.run(get_activity_details("123"))
+    result = asyncio.run(get_activity_details(123))
     assert "Activity: Morning Ride" in result
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,145 @@
+import sys
+import pathlib
+import asyncio
+
+sys.path.append(
+    str(pathlib.Path(__file__).resolve().parents[1] / "src" / "intervals_mcp_server")
+)
+import pytest
+from intervals_mcp_server.server import (
+    get_activities,
+    get_activity_details,
+    get_events,
+    get_event_by_id,
+    get_wellness_data,
+    get_activity_intervals,
+)
+
+
+def test_get_activities(monkeypatch):
+    sample = {
+        "name": "Morning Ride",
+        "id": 123,
+        "type": "Ride",
+        "startTime": "2024-01-01T08:00:00Z",
+        "distance": 1000,
+        "duration": 3600,
+    }
+
+    async def fake_request(*args, **kwargs):
+        return [sample]
+
+    monkeypatch.setattr("intervals_mcp_server.server.make_intervals_request", fake_request)
+    result = asyncio.run(get_activities(athlete_id="1", limit=1, include_unnamed=True))
+    assert "Morning Ride" in result
+    assert "Activities:" in result
+
+
+def test_get_activity_details(monkeypatch):
+    sample = {
+        "name": "Morning Ride",
+        "id": 123,
+        "type": "Ride",
+        "startTime": "2024-01-01T08:00:00Z",
+        "distance": 1000,
+        "duration": 3600,
+    }
+
+    async def fake_request(*args, **kwargs):
+        return sample
+
+    monkeypatch.setattr("intervals_mcp_server.server.make_intervals_request", fake_request)
+    result = asyncio.run(get_activity_details("123"))
+    assert "Activity: Morning Ride" in result
+
+
+def test_get_events(monkeypatch):
+    event = {
+        "date": "2024-01-01",
+        "id": "e1",
+        "name": "Test Event",
+        "description": "desc",
+        "race": True,
+    }
+
+    async def fake_request(*args, **kwargs):
+        return [event]
+
+    monkeypatch.setattr("intervals_mcp_server.server.make_intervals_request", fake_request)
+    result = asyncio.run(get_events(athlete_id="1", start_date="2024-01-01", end_date="2024-01-02"))
+    assert "Test Event" in result
+    assert "Events:" in result
+
+
+def test_get_event_by_id(monkeypatch):
+    event = {
+        "id": "e1",
+        "date": "2024-01-01",
+        "name": "Test Event",
+        "description": "desc",
+        "race": True,
+    }
+
+    async def fake_request(*args, **kwargs):
+        return event
+
+    monkeypatch.setattr("intervals_mcp_server.server.make_intervals_request", fake_request)
+    result = asyncio.run(get_event_by_id("e1", athlete_id="1"))
+    assert "Event Details:" in result
+    assert "Test Event" in result
+
+
+def test_get_wellness_data(monkeypatch):
+    wellness = {
+        "2024-01-01": {
+            "id": "w1",
+            "date": "2024-01-01",
+            "ctl": 75,
+            "sleepSecs": 28800,
+        }
+    }
+
+    async def fake_request(*args, **kwargs):
+        return wellness
+
+    monkeypatch.setattr("intervals_mcp_server.server.make_intervals_request", fake_request)
+    result = asyncio.run(get_wellness_data(athlete_id="1"))
+    assert "Wellness Data:" in result
+    assert "2024-01-01" in result
+
+
+def test_get_activity_intervals(monkeypatch):
+    intervals_data = {
+        "id": "i1",
+        "analyzed": True,
+        "icu_intervals": [
+            {
+                "type": "work",
+                "label": "Rep 1",
+                "elapsed_time": 60,
+                "moving_time": 60,
+                "distance": 100,
+                "average_watts": 200,
+                "max_watts": 300,
+                "average_watts_kg": 3.0,
+                "max_watts_kg": 5.0,
+                "weighted_average_watts": 220,
+                "intensity": 0.8,
+                "training_load": 10,
+                "average_heartrate": 150,
+                "max_heartrate": 160,
+                "average_cadence": 90,
+                "max_cadence": 100,
+                "average_speed": 6,
+                "max_speed": 8,
+            }
+        ],
+    }
+
+    async def fake_request(*args, **kwargs):
+        return intervals_data
+
+    monkeypatch.setattr("intervals_mcp_server.server.make_intervals_request", fake_request)
+    result = asyncio.run(get_activity_intervals("123"))
+    assert "Intervals Analysis:" in result
+    assert "Rep 1" in result


### PR DESCRIPTION
## Summary
- add tests for server tools
- cover formatting utilities with unit tests
- configure Hatch to run `pytest` and set pytest options

## Testing
- `pytest -q`