### PR TITLE
[intervals-mcp-server] Validates api key is not empty and athlete id matches expected pattern

### DIFF
--- a/src/intervals_mcp_server/server.py
+++ b/src/intervals_mcp_server/server.py
@@ -20,6 +20,7 @@ The server is designed to be run as a standalone script.
 from json import JSONDecodeError
 import logging
 import os
+import re
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from http import HTTPStatus
@@ -77,6 +78,15 @@ INTERVALS_API_BASE_URL = os.getenv(
 API_KEY = os.getenv("API_KEY", "")  # Provide default empty string
 ATHLETE_ID = os.getenv("ATHLETE_ID", "")  # Default athlete ID from .env
 USER_AGENT = "intervalsicu-mcp-server/1.0"
+
+# Validate environment variables on import
+if API_KEY == "":
+    raise ValueError("API_KEY environment variable is not set or empty")
+
+if not re.fullmatch(r"i\d+", ATHLETE_ID):
+    raise ValueError(
+        "ATHLETE_ID must start with 'i' followed by digits, e.g. i123456"
+    )
 
 
 async def make_intervals_request(

--- a/src/intervals_mcp_server/server.py
+++ b/src/intervals_mcp_server/server.py
@@ -5,16 +5,30 @@ This module implements a Model Context Protocol (MCP) server for connecting
 Claude with the Intervals.icu API. It provides tools for retrieving and managing
 athlete data, including activities, events, workouts, and wellness metrics.
 
-Key features:
-- Activity retrieval and detailed analysis
-- Event management (races, workouts, calendar items)
-- Wellness data tracking and visualization
-- Error handling with user-friendly messages
-- Configurable parameters with environment variable support
+Main Features:
+    - Activity retrieval and detailed analysis
+    - Event management (races, workouts, calendar items)
+    - Wellness data tracking and visualization
+    - Error handling with user-friendly messages
+    - Configurable parameters with environment variable support
 
-The server follows MCP specifications and uses the Python MCP SDK.
+Usage:
+    This server is designed to be run as a standalone script and exposes several MCP tools
+    for use with Claude Desktop or other MCP-compatible clients. The server loads configuration
+    from environment variables (optionally via a .env file) and communicates with the Intervals.icu API.
 
-The server is designed to be run as a standalone script.
+    To run the server:
+        $ python src/intervals_mcp_server/server.py
+
+    MCP tools provided:
+        - get_activities
+        - get_activity_details
+        - get_events
+        - get_event_by_id
+        - get_wellness_data
+        - get_activity_intervals
+
+    See the README for more details on configuration and usage.
 """
 
 from json import JSONDecodeError
@@ -61,7 +75,12 @@ httpx_client = httpx.AsyncClient()
 
 @asynccontextmanager
 async def lifespan(app: FastMCP):
-    """Ensure the shared httpx client is closed when the server stops."""
+    """
+    Context manager to ensure the shared httpx client is closed when the server stops.
+
+    Args:
+        app (FastMCP): The MCP server application instance.
+    """
     try:
         yield
     finally:
@@ -92,8 +111,17 @@ if not re.fullmatch(r"i\d+", ATHLETE_ID):
 async def make_intervals_request(
     url: str, api_key: str | None = None, params: dict[str, Any] | None = None
 ) -> dict[str, Any] | list[dict[str, Any]]:
-    """Make a GET request to the Intervals.icu API with proper error handling."""
+    """
+    Make a GET request to the Intervals.icu API with proper error handling.
 
+    Args:
+        url (str): The API endpoint path (e.g., '/athlete/{id}/activities').
+        api_key (str | None): Optional API key to use for authentication. Defaults to the global API_KEY.
+        params (dict[str, Any] | None): Optional query parameters for the request.
+
+    Returns:
+        dict[str, Any] | list[dict[str, Any]]: The parsed JSON response from the API, or an error dict.
+    """
     headers = {"User-Agent": USER_AGENT, "Accept": "application/json"}
 
     # Use provided api_key or fall back to global API_KEY

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,3 +1,9 @@
+"""
+Unit tests for formatting utilities in intervals_mcp_server.utils.formatting.
+
+These tests verify that the formatting functions produce expected output strings for activities, workouts, wellness entries, events, and intervals.
+"""
+
 from intervals_mcp_server.utils.formatting import (
     format_activity_summary,
     format_workout,
@@ -9,6 +15,9 @@ from intervals_mcp_server.utils.formatting import (
 
 
 def test_format_activity_summary():
+    """
+    Test that format_activity_summary returns a string containing the activity name and ID.
+    """
     data = {
         "name": "Morning Ride",
         "id": 1,
@@ -23,6 +32,9 @@ def test_format_activity_summary():
 
 
 def test_format_workout():
+    """
+    Test that format_workout returns a string containing the workout name and interval count.
+    """
     workout = {
         "name": "Workout1",
         "description": "desc",
@@ -37,6 +49,9 @@ def test_format_workout():
 
 
 def test_format_wellness_entry():
+    """
+    Test that format_wellness_entry returns a string containing the date and fitness (CTL).
+    """
     entry = {
         "date": "2024-01-01",
         "ctl": 70,
@@ -49,6 +64,9 @@ def test_format_wellness_entry():
 
 
 def test_format_event_summary():
+    """
+    Test that format_event_summary returns a string containing the event date and type.
+    """
     event = {
         "date": "2024-01-01",
         "id": "e1",
@@ -62,6 +80,9 @@ def test_format_event_summary():
 
 
 def test_format_event_details():
+    """
+    Test that format_event_details returns a string containing event and workout details.
+    """
     event = {
         "id": "e1",
         "date": "2024-01-01",
@@ -85,6 +106,9 @@ def test_format_event_details():
 
 
 def test_format_intervals():
+    """
+    Test that format_intervals returns a string containing interval analysis and the interval label.
+    """
     intervals_data = {
         "id": "i1",
         "analyzed": True,

--- a/tests/test_make_intervals_request.py
+++ b/tests/test_make_intervals_request.py
@@ -1,15 +1,22 @@
+"""
+Unit tests for the make_intervals_request function in intervals_mcp_server.server.
+
+These tests focus on error handling, particularly the scenario where the API returns invalid JSON.
+Mock classes are used to simulate httpx responses and client behavior.
+"""
+
 import asyncio
 import logging
 from json import JSONDecodeError
-import os
-
-os.environ.setdefault("API_KEY", "test-key")
-os.environ.setdefault("ATHLETE_ID", "i123456")
 
 import intervals_mcp_server.server as server
 
 
 class MockBadJSONResponse:
+    """
+    Simulates an httpx response object that returns invalid JSON content.
+    Used to test error handling for JSONDecodeError in make_intervals_request.
+    """
     def __init__(self):
         self.content = b"bad"
         self.status_code = 200
@@ -22,6 +29,10 @@ class MockBadJSONResponse:
 
 
 class MockAsyncClient:
+    """
+    Simulates an httpx.AsyncClient for use in monkeypatching.
+    Always returns a MockBadJSONResponse from get().
+    """
     def __init__(self, *args, **kwargs):
         pass
 
@@ -36,6 +47,10 @@ class MockAsyncClient:
 
 
 def test_make_intervals_request_bad_json(monkeypatch, caplog):
+    """
+    Test that make_intervals_request returns an error dict when the response contains invalid JSON.
+    Ensures proper logging and error message content.
+    """
     monkeypatch.setattr(server, "httpx_client", MockAsyncClient())
 
     with caplog.at_level(logging.ERROR):

--- a/tests/test_make_intervals_request.py
+++ b/tests/test_make_intervals_request.py
@@ -1,8 +1,10 @@
 import asyncio
 import logging
 from json import JSONDecodeError
+import os
 
-import httpx
+os.environ.setdefault("API_KEY", "test-key")
+os.environ.setdefault("ATHLETE_ID", "i123456")
 
 import intervals_mcp_server.server as server
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,11 +1,13 @@
 import sys
 import pathlib
 import asyncio
+import os
 
 sys.path.append(
     str(pathlib.Path(__file__).resolve().parents[1] / "src" / "intervals_mcp_server")
 )
-import pytest
+os.environ.setdefault("API_KEY", "test-key")
+os.environ.setdefault("ATHLETE_ID", "i123456")
 from intervals_mcp_server.server import (
     get_activities,
     get_activity_details,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,13 +1,24 @@
+"""
+Unit tests for the main MCP server tool functions in intervals_mcp_server.server.
+
+These tests use monkeypatching to mock API responses and verify the formatting and output of each tool function:
+- get_activities
+- get_activity_details
+- get_events
+- get_event_by_id
+- get_wellness_data
+- get_activity_intervals
+
+The tests ensure that the server's public API returns expected strings and handles data correctly.
+"""
+
 import sys
 import pathlib
 import asyncio
-import os
 
 sys.path.append(
     str(pathlib.Path(__file__).resolve().parents[1] / "src" / "intervals_mcp_server")
 )
-os.environ.setdefault("API_KEY", "test-key")
-os.environ.setdefault("ATHLETE_ID", "i123456")
 from intervals_mcp_server.server import (
     get_activities,
     get_activity_details,
@@ -19,6 +30,9 @@ from intervals_mcp_server.server import (
 
 
 def test_get_activities(monkeypatch):
+    """
+    Test get_activities returns a formatted string containing activity details when given a sample activity.
+    """
     sample = {
         "name": "Morning Ride",
         "id": 123,
@@ -38,6 +52,9 @@ def test_get_activities(monkeypatch):
 
 
 def test_get_activity_details(monkeypatch):
+    """
+    Test get_activity_details returns a formatted string with the activity name and details.
+    """
     sample = {
         "name": "Morning Ride",
         "id": 123,
@@ -56,6 +73,9 @@ def test_get_activity_details(monkeypatch):
 
 
 def test_get_events(monkeypatch):
+    """
+    Test get_events returns a formatted string containing event details when given a sample event.
+    """
     event = {
         "date": "2024-01-01",
         "id": "e1",
@@ -74,6 +94,9 @@ def test_get_events(monkeypatch):
 
 
 def test_get_event_by_id(monkeypatch):
+    """
+    Test get_event_by_id returns a formatted string with event details for a given event ID.
+    """
     event = {
         "id": "e1",
         "date": "2024-01-01",
@@ -92,6 +115,9 @@ def test_get_event_by_id(monkeypatch):
 
 
 def test_get_wellness_data(monkeypatch):
+    """
+    Test get_wellness_data returns a formatted string containing wellness data for a given athlete.
+    """
     wellness = {
         "2024-01-01": {
             "id": "w1",
@@ -111,6 +137,9 @@ def test_get_wellness_data(monkeypatch):
 
 
 def test_get_activity_intervals(monkeypatch):
+    """
+    Test get_activity_intervals returns a formatted string with interval analysis for a given activity.
+    """
     intervals_data = {
         "id": "i1",
         "analyzed": True,


### PR DESCRIPTION
## Summary
- Validates api key is not empty and athlete id matches expected pattern.

## Testing
- `ruff check .`
- `mypy src tests` *(fails: Cannot find implementation or library stubs for several modules)*
- `pytest -q` *(fails: command not found)*