### PR TITLE
Fix: use start_date_local key to get event date

### DIFF
--- a/src/intervals_mcp_server/utils/formatting.py
+++ b/src/intervals_mcp_server/utils/formatting.py
@@ -203,7 +203,7 @@ Last Updated: {entry.get("updated", "Unknown")}"""
 def format_event_summary(event: dict[str, Any]) -> str:
     """Format a basic event summary into a readable string."""
 
-    event_date = event.get("date", "Unknown")
+    event_date = event.get("start_date_local", "Unknown")
     event_type = (
         "Workout" if event.get("workout") else "Race" if event.get("race") else "Other"
     )


### PR DESCRIPTION
I noticed that my planned workouts did not show any dates because the `date` key is not present for the `/events` route (the MCP server would return `Unknown` for all upcoming planned workouts)

After manually checking the API response and looking at david's post [here](https://forum.intervals.icu/t/api-access-to-intervals-icu/609/4) the correct key is actually `start_date_local` rather than `date`. 

This PR changes the key from `date` to `start_date_local` to retrieve the event date. 