### PR TITLE
[intervals-mcp-server] Address pylint warnings and update tests

### DIFF
--- a/src/intervals_mcp_server/server.py
+++ b/src/intervals_mcp_server/server.py
@@ -74,12 +74,12 @@ httpx_client = httpx.AsyncClient()
 
 
 @asynccontextmanager
-async def lifespan(app: FastMCP):
+async def lifespan(_app: FastMCP):
     """
     Context manager to ensure the shared httpx client is closed when the server stops.
 
     Args:
-        app (FastMCP): The MCP server application instance.
+        _app (FastMCP): The MCP server application instance.
     """
     try:
         yield
@@ -169,9 +169,9 @@ async def make_intervals_request(
     except httpx.RequestError as e:
         logger.error("Request error: %s", str(e))
         return {"error": True, "message": f"Request error: {str(e)}"}
-    except Exception as e:
-        logger.error("Unexpected error: %s", str(e))
-        return {"error": True, "message": f"Unexpected error: {str(e)}"}
+    except httpx.HTTPError as e:
+        logger.error("HTTP client error: %s", str(e))
+        return {"error": True, "message": f"HTTP client error: {str(e)}"}
 
 
 # ----- MCP Tool Implementations ----- #
@@ -291,9 +291,12 @@ async def get_activities(
 
     if not activities:
         if include_unnamed:
-            return f"No valid activities found for athlete {athlete_id_to_use} in the specified date range."
-        else:
-            return f"No named activities found for athlete {athlete_id_to_use} in the specified date range. Try with include_unnamed=True to see all activities."
+            return (
+                f"No valid activities found for athlete {athlete_id_to_use} in the specified date range."
+            )
+        return (
+            f"No named activities found for athlete {athlete_id_to_use} in the specified date range. Try with include_unnamed=True to see all activities."
+        )
 
     activities_summary = "Activities:\n\n"
     for activity in activities:

--- a/src/intervals_mcp_server/utils/formatting.py
+++ b/src/intervals_mcp_server/utils/formatting.py
@@ -199,10 +199,9 @@ Comments: {entry.get("comments", "No comments")}
 Status: {"Locked" if entry.get("locked") else "Unlocked"}
 Last Updated: {entry.get("updated", "Unknown")}"""
 
-
 def format_event_summary(event: dict[str, Any]) -> str:
     """Format a basic event summary into a readable string."""
-    
+
     # Update to check for "date" if "start_date_local" is not provided
     event_date = event.get("start_date_local", event.get("date", "Unknown"))
     event_type = (
@@ -285,76 +284,47 @@ Analyzed: {intervals_data.get("analyzed", "N/A")}
         result += "Individual Intervals:\n\n"
 
         for i, interval in enumerate(intervals_data["icu_intervals"], 1):
-            interval_type = interval.get("type", "Unknown")
-            label = interval.get("label", f"Interval {i}")
-
-            # Format duration, distance, and time information
-            moving_time = interval.get("moving_time", 0)
-            elapsed_time = interval.get("elapsed_time", 0)
-            distance = interval.get("distance", 0)
-
-            # Format power metrics
-            avg_watts = interval.get("average_watts", 0)
-            max_watts = interval.get("max_watts", 0)
-            avg_watts_kg = interval.get("average_watts_kg", 0)
-            max_watts_kg = interval.get("max_watts_kg", 0)
-            w_avg = interval.get("weighted_average_watts", 0)
-            intensity = interval.get("intensity", 0)
-            training_load = interval.get("training_load", 0)
-
-            # Format heart rate metrics
-            avg_hr = interval.get("average_heartrate", 0)
-            max_hr = interval.get("max_heartrate", 0)
-
-            # Format cadence metrics
-            avg_cadence = interval.get("average_cadence", 0)
-            max_cadence = interval.get("max_cadence", 0)
-
-            # Format speed metrics
-            avg_speed = interval.get("average_speed", 0)
-            max_speed = interval.get("max_speed", 0)
-
-            result += f"""[{i}] {label} ({interval_type})
-Duration: {elapsed_time} seconds (moving: {moving_time} seconds)
-Distance: {distance} meters
-Start-End Indices: {interval.get("start_index", 0)}-{interval.get("end_index", 0)}
+            result += f"""[{i}] {interval.get('label', f'Interval {i}')} ({interval.get('type', 'Unknown')})
+Duration: {interval.get('elapsed_time', 0)} seconds (moving: {interval.get('moving_time', 0)} seconds)
+Distance: {interval.get('distance', 0)} meters
+Start-End Indices: {interval.get('start_index', 0)}-{interval.get('end_index', 0)}
 
 Power Metrics:
-  Average Power: {avg_watts} watts ({avg_watts_kg} W/kg)
-  Max Power: {max_watts} watts ({max_watts_kg} W/kg)
-  Weighted Avg Power: {w_avg} watts
-  Intensity: {intensity}
-  Training Load: {training_load}
-  Joules: {interval.get("joules", 0)}
-  Joules > FTP: {interval.get("joules_above_ftp", 0)}
-  Power Zone: {interval.get("zone", "N/A")} ({interval.get("zone_min_watts", 0)}-{interval.get("zone_max_watts", 0)} watts)
-  W' Balance: Start {interval.get("wbal_start", 0)}, End {interval.get("wbal_end", 0)}
-  L/R Balance: {interval.get("avg_lr_balance", 0)}
-  Variability: {interval.get("w5s_variability", 0)}
-  Torque: Avg {interval.get("average_torque", 0)}, Min {interval.get("min_torque", 0)}, Max {interval.get("max_torque", 0)}
+  Average Power: {interval.get('average_watts', 0)} watts ({interval.get('average_watts_kg', 0)} W/kg)
+  Max Power: {interval.get('max_watts', 0)} watts ({interval.get('max_watts_kg', 0)} W/kg)
+  Weighted Avg Power: {interval.get('weighted_average_watts', 0)} watts
+  Intensity: {interval.get('intensity', 0)}
+  Training Load: {interval.get('training_load', 0)}
+  Joules: {interval.get('joules', 0)}
+  Joules > FTP: {interval.get('joules_above_ftp', 0)}
+  Power Zone: {interval.get('zone', 'N/A')} ({interval.get('zone_min_watts', 0)}-{interval.get('zone_max_watts', 0)} watts)
+  W' Balance: Start {interval.get('wbal_start', 0)}, End {interval.get('wbal_end', 0)}
+  L/R Balance: {interval.get('avg_lr_balance', 0)}
+  Variability: {interval.get('w5s_variability', 0)}
+  Torque: Avg {interval.get('average_torque', 0)}, Min {interval.get('min_torque', 0)}, Max {interval.get('max_torque', 0)}
 
 Heart Rate & Metabolic:
-  Heart Rate: Avg {avg_hr}, Min {interval.get("min_heartrate", 0)}, Max {max_hr} bpm
-  Decoupling: {interval.get("decoupling", 0)}
-  DFA α1: {interval.get("average_dfa_a1", 0)}
-  Respiration: {interval.get("average_respiration", 0)} breaths/min
-  EPOC: {interval.get("average_epoc", 0)}
-  SmO2: {interval.get("average_smo2", 0)}% / {interval.get("average_smo2_2", 0)}%
-  THb: {interval.get("average_thb", 0)} / {interval.get("average_thb_2", 0)}
+  Heart Rate: Avg {interval.get('average_heartrate', 0)}, Min {interval.get('min_heartrate', 0)}, Max {interval.get('max_heartrate', 0)} bpm
+  Decoupling: {interval.get('decoupling', 0)}
+  DFA α1: {interval.get('average_dfa_a1', 0)}
+  Respiration: {interval.get('average_respiration', 0)} breaths/min
+  EPOC: {interval.get('average_epoc', 0)}
+  SmO2: {interval.get('average_smo2', 0)}% / {interval.get('average_smo2_2', 0)}%
+  THb: {interval.get('average_thb', 0)} / {interval.get('average_thb_2', 0)}
 
 Speed & Cadence:
-  Speed: Avg {avg_speed}, Min {interval.get("min_speed", 0)}, Max {max_speed} m/s
-  GAP: {interval.get("gap", 0)} m/s
-  Cadence: Avg {avg_cadence}, Min {interval.get("min_cadence", 0)}, Max {max_cadence} rpm
-  Stride: {interval.get("average_stride", 0)}
+  Speed: Avg {interval.get('average_speed', 0)}, Min {interval.get('min_speed', 0)}, Max {interval.get('max_speed', 0)} m/s
+  GAP: {interval.get('gap', 0)} m/s
+  Cadence: Avg {interval.get('average_cadence', 0)}, Min {interval.get('min_cadence', 0)}, Max {interval.get('max_cadence', 0)} rpm
+  Stride: {interval.get('average_stride', 0)}
 
 Elevation & Environment:
-  Elevation Gain: {interval.get("total_elevation_gain", 0)} meters
-  Altitude: Min {interval.get("min_altitude", 0)}, Max {interval.get("max_altitude", 0)} meters
-  Gradient: {interval.get("average_gradient", 0)}%
-  Temperature: {interval.get("average_temp", 0)}°C (Weather: {interval.get("average_weather_temp", 0)}°C, Feels like: {interval.get("average_feels_like", 0)}°C)
-  Wind: Speed {interval.get("average_wind_speed", 0)} km/h, Gust {interval.get("average_wind_gust", 0)} km/h, Direction {interval.get("prevailing_wind_deg", 0)}°
-  Headwind: {interval.get("headwind_percent", 0)}%, Tailwind: {interval.get("tailwind_percent", 0)}%
+  Elevation Gain: {interval.get('total_elevation_gain', 0)} meters
+  Altitude: Min {interval.get('min_altitude', 0)}, Max {interval.get('max_altitude', 0)} meters
+  Gradient: {interval.get('average_gradient', 0)}%
+  Temperature: {interval.get('average_temp', 0)}°C (Weather: {interval.get('average_weather_temp', 0)}°C, Feels like: {interval.get('average_feels_like', 0)}°C)
+  Wind: Speed {interval.get('average_wind_speed', 0)} km/h, Gust {interval.get('average_wind_gust', 0)} km/h, Direction {interval.get('prevailing_wind_deg', 0)}°
+  Headwind: {interval.get('headwind_percent', 0)}%, Tailwind: {interval.get('tailwind_percent', 0)}%
 
 """
 
@@ -363,32 +333,16 @@ Elevation & Environment:
         result += "Interval Groups:\n\n"
 
         for i, group in enumerate(intervals_data["icu_groups"], 1):
-            group_id = group.get("id", f"Group {i}")
+            result += f"""Group: {group.get('id', f'Group {i}')} (Contains {group.get('count', 0)} intervals)
+Duration: {group.get('elapsed_time', 0)} seconds (moving: {group.get('moving_time', 0)} seconds)
+Distance: {group.get('distance', 0)} meters
+Start-End Indices: {group.get('start_index', 0)}-N/A
 
-            # Format basic group information
-            moving_time = group.get("moving_time", 0)
-            elapsed_time = group.get("elapsed_time", 0)
-            distance = group.get("distance", 0)
-            count = group.get("count", 0)
-
-            # Format power metrics
-            avg_watts = group.get("average_watts", 0)
-            max_watts = group.get("max_watts", 0)
-            avg_watts_kg = group.get("average_watts_kg", 0)
-            max_watts_kg = group.get("max_watts_kg", 0)
-            w_avg = group.get("weighted_average_watts", 0)
-            intensity = group.get("intensity", 0)
-
-            result += f"""Group: {group_id} (Contains {count} intervals)
-Duration: {elapsed_time} seconds (moving: {moving_time} seconds)
-Distance: {distance} meters
-Start-End Indices: {group.get("start_index", 0)}-N/A
-
-Power: Avg {avg_watts} watts ({avg_watts_kg} W/kg), Max {max_watts} watts
-W. Avg Power: {w_avg} watts, Intensity: {intensity}
-Heart Rate: Avg {group.get("average_heartrate", 0)}, Max {group.get("max_heartrate", 0)} bpm
-Speed: Avg {group.get("average_speed", 0)}, Max {group.get("max_speed", 0)} m/s
-Cadence: Avg {group.get("average_cadence", 0)}, Max {group.get("max_cadence", 0)} rpm
+Power: Avg {group.get('average_watts', 0)} watts ({group.get('average_watts_kg', 0)} W/kg), Max {group.get('max_watts', 0)} watts
+W. Avg Power: {group.get('weighted_average_watts', 0)} watts, Intensity: {group.get('intensity', 0)}
+Heart Rate: Avg {group.get('average_heartrate', 0)}, Max {group.get('max_heartrate', 0)} bpm
+Speed: Avg {group.get('average_speed', 0)}, Max {group.get('max_speed', 0)} m/s
+Cadence: Avg {group.get('average_cadence', 0)}, Max {group.get('max_cadence', 0)} rpm
 
 """
 

--- a/tests/sample_data.py
+++ b/tests/sample_data.py
@@ -1,0 +1,26 @@
+INTERVALS_DATA = {
+    "id": "i1",
+    "analyzed": True,
+    "icu_intervals": [
+        {
+            "type": "work",
+            "label": "Rep 1",
+            "elapsed_time": 60,
+            "moving_time": 60,
+            "distance": 100,
+            "average_watts": 200,
+            "max_watts": 300,
+            "average_watts_kg": 3.0,
+            "max_watts_kg": 5.0,
+            "weighted_average_watts": 220,
+            "intensity": 0.8,
+            "training_load": 10,
+            "average_heartrate": 150,
+            "max_heartrate": 160,
+            "average_cadence": 90,
+            "max_cadence": 100,
+            "average_speed": 6,
+            "max_speed": 8,
+        }
+    ],
+}

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -12,6 +12,7 @@ from intervals_mcp_server.utils.formatting import (
     format_event_details,
     format_intervals,
 )
+from tests.sample_data import INTERVALS_DATA
 
 
 def test_format_activity_summary():
@@ -109,32 +110,6 @@ def test_format_intervals():
     """
     Test that format_intervals returns a string containing interval analysis and the interval label.
     """
-    intervals_data = {
-        "id": "i1",
-        "analyzed": True,
-        "icu_intervals": [
-            {
-                "type": "work",
-                "label": "Rep 1",
-                "elapsed_time": 60,
-                "moving_time": 60,
-                "distance": 100,
-                "average_watts": 200,
-                "max_watts": 300,
-                "average_watts_kg": 3.0,
-                "max_watts_kg": 5.0,
-                "weighted_average_watts": 220,
-                "intensity": 0.8,
-                "training_load": 10,
-                "average_heartrate": 150,
-                "max_heartrate": 160,
-                "average_cadence": 90,
-                "max_cadence": 100,
-                "average_speed": 6,
-                "max_speed": 8,
-            }
-        ],
-    }
-    result = format_intervals(intervals_data)
+    result = format_intervals(INTERVALS_DATA)
     assert "Intervals Analysis:" in result
     assert "Rep 1" in result

--- a/tests/test_make_intervals_request.py
+++ b/tests/test_make_intervals_request.py
@@ -7,9 +7,15 @@ Mock classes are used to simulate httpx responses and client behavior.
 
 import asyncio
 import logging
+import pathlib
+import sys
 from json import JSONDecodeError
 
-import intervals_mcp_server.server as server
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+import os
+os.environ.setdefault("API_KEY", "test")
+os.environ.setdefault("ATHLETE_ID", "i1")
+from intervals_mcp_server import server
 
 
 class MockBadJSONResponse:
@@ -22,9 +28,11 @@ class MockBadJSONResponse:
         self.status_code = 200
 
     def raise_for_status(self):
+        """Mock raise_for_status that does nothing."""
         return None
 
     def json(self):
+        """Raise JSONDecodeError to simulate invalid JSON."""
         raise JSONDecodeError("Expecting value", "bad", 0)
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,10 +15,11 @@ The tests ensure that the server's public API returns expected strings and handl
 import sys
 import pathlib
 import asyncio
+import os
 
-sys.path.append(
-    str(pathlib.Path(__file__).resolve().parents[1] / "src" / "intervals_mcp_server")
-)
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+os.environ.setdefault("API_KEY", "test")
+os.environ.setdefault("ATHLETE_ID", "i1")
 from intervals_mcp_server.server import (
     get_activities,
     get_activity_details,
@@ -27,6 +28,7 @@ from intervals_mcp_server.server import (
     get_wellness_data,
     get_activity_intervals,
 )
+from tests.sample_data import INTERVALS_DATA
 
 
 def test_get_activities(monkeypatch):
@@ -42,7 +44,7 @@ def test_get_activities(monkeypatch):
         "duration": 3600,
     }
 
-    async def fake_request(*args, **kwargs):
+    async def fake_request(*_args, **_kwargs):
         return [sample]
 
     monkeypatch.setattr("intervals_mcp_server.server.make_intervals_request", fake_request)
@@ -64,7 +66,7 @@ def test_get_activity_details(monkeypatch):
         "duration": 3600,
     }
 
-    async def fake_request(*args, **kwargs):
+    async def fake_request(*_args, **_kwargs):
         return sample
 
     monkeypatch.setattr("intervals_mcp_server.server.make_intervals_request", fake_request)
@@ -84,7 +86,7 @@ def test_get_events(monkeypatch):
         "race": True,
     }
 
-    async def fake_request(*args, **kwargs):
+    async def fake_request(*_args, **_kwargs):
         return [event]
 
     monkeypatch.setattr("intervals_mcp_server.server.make_intervals_request", fake_request)
@@ -105,7 +107,7 @@ def test_get_event_by_id(monkeypatch):
         "race": True,
     }
 
-    async def fake_request(*args, **kwargs):
+    async def fake_request(*_args, **_kwargs):
         return event
 
     monkeypatch.setattr("intervals_mcp_server.server.make_intervals_request", fake_request)
@@ -127,7 +129,7 @@ def test_get_wellness_data(monkeypatch):
         }
     }
 
-    async def fake_request(*args, **kwargs):
+    async def fake_request(*_args, **_kwargs):
         return wellness
 
     monkeypatch.setattr("intervals_mcp_server.server.make_intervals_request", fake_request)
@@ -140,35 +142,8 @@ def test_get_activity_intervals(monkeypatch):
     """
     Test get_activity_intervals returns a formatted string with interval analysis for a given activity.
     """
-    intervals_data = {
-        "id": "i1",
-        "analyzed": True,
-        "icu_intervals": [
-            {
-                "type": "work",
-                "label": "Rep 1",
-                "elapsed_time": 60,
-                "moving_time": 60,
-                "distance": 100,
-                "average_watts": 200,
-                "max_watts": 300,
-                "average_watts_kg": 3.0,
-                "max_watts_kg": 5.0,
-                "weighted_average_watts": 220,
-                "intensity": 0.8,
-                "training_load": 10,
-                "average_heartrate": 150,
-                "max_heartrate": 160,
-                "average_cadence": 90,
-                "max_cadence": 100,
-                "average_speed": 6,
-                "max_speed": 8,
-            }
-        ],
-    }
-
-    async def fake_request(*args, **kwargs):
-        return intervals_data
+    async def fake_request(*_args, **_kwargs):
+        return INTERVALS_DATA
 
     monkeypatch.setattr("intervals_mcp_server.server.make_intervals_request", fake_request)
     result = asyncio.run(get_activity_intervals("123"))


### PR DESCRIPTION
## Summary
- handle FastMCP lifespan argument
- narrow exception handling in `make_intervals_request`
- simplify activity return logic
- trim trailing whitespace and reduce locals in formatting helpers
- restructure tests to avoid importing installed package

## Testing
- `ruff check .`
- `mypy src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bdf884d30833399b16a9e8b037dd2