### PR TITLE
[intervals-mcp-server] Fix RPE in formatted activity output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,7 @@ Before opening a pull request, ensure all checks pass locally:
 ruff check .
 mypy src tests
 uv run --locked pytest
+```
 
 ## Pull request guidelines
 

--- a/src/intervals_mcp_server/utils/formatting.py
+++ b/src/intervals_mcp_server/utils/formatting.py
@@ -20,6 +20,9 @@ def format_activity_summary(activity: dict[str, Any]) -> str:
         except ValueError:
             pass
 
+    rpe = activity.get("perceived_exertion", None)
+    if rpe is None:
+        rpe = activity.get("icu_rpe", "N/A")
     return f"""
 Activity: {activity.get("name", "Unnamed")}
 ID: {activity.get("id", "N/A")}
@@ -57,7 +60,7 @@ Max Speed: {activity.get("max_speed", "N/A")} m/s
 Average Stride: {activity.get("average_stride", "N/A")}
 L/R Balance: {activity.get("avg_lr_balance", "N/A")}
 Weight: {activity.get("icu_weight", "N/A")} kg
-RPE: {activity.get("perceived_exertion", activity.get("icu_rpe", "N/A"))}/10
+RPE: {rpe}/10
 Session RPE: {activity.get("session_rpe", "N/A")}
 Feel: {activity.get("feel", "N/A")}/10
 

--- a/src/intervals_mcp_server/utils/formatting.py
+++ b/src/intervals_mcp_server/utils/formatting.py
@@ -57,7 +57,7 @@ Max Speed: {activity.get("max_speed", "N/A")} m/s
 Average Stride: {activity.get("average_stride", "N/A")}
 L/R Balance: {activity.get("avg_lr_balance", "N/A")}
 Weight: {activity.get("icu_weight", "N/A")} kg
-Perceived Exertion: {activity.get("perceived_exertion", activity.get("icu_rpe", "N/A"))}/10
+RPE: {activity.get("perceived_exertion", activity.get("icu_rpe", "N/A"))}/10
 Session RPE: {activity.get("session_rpe", "N/A")}
 Feel: {activity.get("feel", "N/A")}/10
 

--- a/src/intervals_mcp_server/utils/formatting.py
+++ b/src/intervals_mcp_server/utils/formatting.py
@@ -62,7 +62,7 @@ Max Speed: {activity.get("max_speed", "N/A")} m/s
 Average Stride: {activity.get("average_stride", "N/A")}
 L/R Balance: {activity.get("avg_lr_balance", "N/A")}
 Weight: {activity.get("icu_weight", "N/A")} kg
-RPE: {rpe}/10
+RPE: {rpe}
 Session RPE: {activity.get("session_rpe", "N/A")}
 Feel: {activity.get("feel", "N/A")}/10
 

--- a/src/intervals_mcp_server/utils/formatting.py
+++ b/src/intervals_mcp_server/utils/formatting.py
@@ -23,6 +23,8 @@ def format_activity_summary(activity: dict[str, Any]) -> str:
     rpe = activity.get("perceived_exertion", None)
     if rpe is None:
         rpe = activity.get("icu_rpe", "N/A")
+    if isinstance(rpe, (int, float)):
+        rpe = f"{rpe}/10"
     return f"""
 Activity: {activity.get("name", "Unnamed")}
 ID: {activity.get("id", "N/A")}


### PR DESCRIPTION
In the output from `get_activity`, I noticed that `icu_rpe` can be populated while `perceived_exertion` is also populated with `null`:

```javascript
{
  // ...
  "perceived_exertion": null,
  "icu_rpe": 8,
  // ...
}
```

This means that we end up with `Perceived Exertion: None` in the formatted MCP response. I've fixed this in this PR.

I also propose renaming `Perceived Exertion` in the formatted output to `RPE`, for consistency with the Intervals.icu UI, as well as the `Session RPE` field.

I also fixed a small typo in `CONTRIBUTING.md` :-)

All tests (ruff, mypy, pytest) are passing.

Thank you for making this MCP server!