### PR TITLE
Fix percentage formatting for ramp intervals in Value.__str__()

### DIFF
--- a/src/intervals_mcp_server/utils/types.py
+++ b/src/intervals_mcp_server/utils/types.py
@@ -154,7 +154,7 @@ class Value:
     def __str__(self) -> str:
         val = ""
         if self.start is not None and self.end is not None:
-            val += f"{self.start} - {self.end} "
+            val += f"{self._format_value(self.start)}-{self._format_value(self.end)} "
         if self.value is not None:
             val += f"{self._format_value(self.value)} "
         if self.units is not None:

--- a/tests/test_value.py
+++ b/tests/test_value.py
@@ -1,0 +1,20 @@
+"""
+Unit tests for the Value dataclass in intervals_mcp_server.utils.types.
+
+These tests verify that the Value dataclass correctly handles:
+- String formatting for percent FTP units
+- Ramp intervals (start/end values)
+"""
+
+from intervals_mcp_server.utils.types import Value, ValueUnits, HrTarget
+
+
+def test_str_percent_ftp():
+    """Test formatting percentage FTP values."""
+    val = Value(value=95.0, units=ValueUnits.PERCENT_FTP)
+    assert str(val) == "95% ftp"
+
+def test_str_ramp_percent_ftp():
+    """Test formatting ramp intervals with percentage FTP."""
+    val = Value(start=65, end=85, units=ValueUnits.PERCENT_FTP)
+    assert str(val) == "65%-85% ftp"


### PR DESCRIPTION
When generating ramp intervals with start/end values, the percentage range was generated with spaces (e.g., "65 - 85 ftp" instead of "65%-85% ftp"). This caused ramp step was invalid.

This fix also applies the _format_value() method to both start and end values to ensure proper percentage formatting.

Example output when generating ramp step
Before fix: "5m ramp 65 - 85 %ftp Build"
<img width="697" height="763" alt="image" src="https://github.com/user-attachments/assets/e23e3bfd-543a-4034-b37b-69ea8bbcb471" />

After fix: "5m ramp 65%-85% ftp Build"
<img width="700" height="766" alt="image" src="https://github.com/user-attachments/assets/d23bb418-fbcc-4a20-a9e5-747920bf584a" />
