### PR TITLE
fix(client): remove unused data parameter in request configuration

### DIFF
--- a/src/intervals_mcp_server/api/client.py
+++ b/src/intervals_mcp_server/api/client.py
@@ -170,7 +170,7 @@ async def make_intervals_request(
         dict[str, Any] | list[dict[str, Any]]: The parsed JSON response from the API, or an error dict.
     """
     # Prepare request configuration
-    full_url, auth, headers, error_msg = _prepare_request_config(url, api_key, method, data)
+    full_url, auth, headers, error_msg = _prepare_request_config(url, api_key, method)
     if error_msg:
         return {"error": True, "message": error_msg}
 


### PR DESCRIPTION
This was causing the tools to not work.
All tests passed.