### PR TITLE
Fix: Remove extra argument in _prepare_request_config call

### DIFF
--- a/src/intervals_mcp_server/api/client.py
+++ b/src/intervals_mcp_server/api/client.py
@@ -170,7 +170,7 @@ async def make_intervals_request(
         dict[str, Any] | list[dict[str, Any]]: The parsed JSON response from the API, or an error dict.
     """
     # Prepare request configuration
-    full_url, auth, headers, error_msg = _prepare_request_config(url, api_key, method, data)
+    full_url, auth, headers, error_msg = _prepare_request_config(url, api_key, method)
     if error_msg:
         return {"error": True, "message": error_msg}
 


### PR DESCRIPTION
## Summary

Fixes a critical TypeError that prevents the MCP server from making API requests.

## Problem

The `_prepare_request_config()` function signature accepts 3 parameters:
```python
def _prepare_request_config(
    url: str,
    api_key: str | None,
    method: str,
)
```

But it was being called with 4 arguments in `make_intervals_request()`:
```python
full_url, auth, headers, error_msg = _prepare_request_config(url, api_key, method, data)
```

This causes:
```
TypeError: _prepare_request_config() takes 3 positional arguments but 4 were given
```

## Root Cause

This bug was introduced in PR #73 ("Modularizes server") when the function was refactored into a new `api/client.py` module. The 'data' parameter was incorrectly included in the call site but never added to the function signature.

## Solution

Remove the unused `data` argument from the function call. The 'data' parameter is not needed in `_prepare_request_config()` because:

1. It only handles request headers and authentication setup
2. The actual HTTP request body data is passed directly to `client.request()` in the `_send_request()` helper function (lines 178-195)
3. Request body configuration has no dependencies on the config preparation step

## Testing

✅ All 17 existing tests pass, including `test_make_intervals_request.py`

## Changed Files

- `src/intervals_mcp_server/api/client.py` (line 173): Removed unnecessary `data` argument from `_prepare_request_config()` call