### PR TITLE
feat: add tags parameter to add_or_update_event

### DIFF
--- a/src/intervals_mcp_server/tools/events.py
+++ b/src/intervals_mcp_server/tools/events.py
@@ -46,13 +46,14 @@ def _prepare_event_data(  # pylint: disable=too-many-arguments,too-many-position
     workout_doc: WorkoutDoc | None,
     moving_time: int | None,
     distance: int | None,
+    tags: list[str] | None,
 ) -> dict[str, Any]:
     """Prepare event data dictionary for API request.
 
     Many arguments are required to match the Intervals.icu API event structure.
     """
     resolved_workout_type = _resolve_workout_type(name, workout_type)
-    return {
+    data: dict[str, Any] = {
         "start_date_local": start_date + "T00:00:00",
         "category": "WORKOUT",
         "name": name,
@@ -61,6 +62,9 @@ def _prepare_event_data(  # pylint: disable=too-many-arguments,too-many-position
         "moving_time": moving_time,
         "distance": distance,
     }
+    if tags:
+        data["tags"] = tags
+    return data
 
 
 def _handle_event_response(
@@ -289,6 +293,7 @@ async def add_or_update_event(  # pylint: disable=too-many-arguments,too-many-po
     workout_doc: WorkoutDoc | None = None,
     moving_time: int | None = None,
     distance: int | None = None,
+    tags: list[str] | None = None,
 ) -> str:
     """Post event for an athlete to Intervals.icu this follows the event api from intervals.icu
     If event_id is provided, the event will be updated instead of created.
@@ -305,6 +310,8 @@ async def add_or_update_event(  # pylint: disable=too-many-arguments,too-many-po
         workout_type: Workout type (e.g. Ride, Run, Swim, Walk, Row)
         moving_time: Total expected moving time of the workout in seconds (optional)
         distance: Total expected distance of the workout in meters (optional)
+        tags: List of tags to apply to the event (e.g., ["sweet-spot", "indoor", "recovery"]).
+              Tags appear as clickable hashtags in the Intervals.icu calendar.
 
     Example:
         "workout_doc": {
@@ -364,7 +371,7 @@ async def add_or_update_event(  # pylint: disable=too-many-arguments,too-many-po
 
     try:
         event_data = _prepare_event_data(
-            name, workout_type, start_date, workout_doc, moving_time, distance
+            name, workout_type, start_date, workout_doc, moving_time, distance, tags
         )
         return await _create_or_update_event_request(
             athlete_id_to_use, api_key, event_data, start_date, event_id

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -254,3 +254,70 @@ def test_add_or_update_event(monkeypatch):
     assert "Successfully created event:" in result
     assert '"id": "e123"' in result
     assert '"name": "Test Workout"' in result
+
+
+def test_add_or_update_event_with_tags(monkeypatch):
+    """
+    Test add_or_update_event includes tags in the API request when provided.
+    """
+    captured_data = {}
+
+    async def fake_post_request(*_args, **kwargs):
+        captured_data.update(kwargs.get("data", {}))
+        return {
+            "id": "e456",
+            "start_date_local": "2024-01-20T00:00:00",
+            "category": "WORKOUT",
+            "name": "Tagged Workout",
+            "type": "Ride",
+            "tags": ["sweet-spot", "indoor"],
+        }
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_post_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.events.make_intervals_request", fake_post_request
+    )
+    result = asyncio.run(
+        add_or_update_event(
+            athlete_id="i1",
+            start_date="2024-01-20",
+            name="Tagged Workout",
+            workout_type="Ride",
+            tags=["sweet-spot", "indoor"],
+        )
+    )
+    assert "Successfully created event:" in result
+    assert '"name": "Tagged Workout"' in result
+    assert captured_data.get("tags") == ["sweet-spot", "indoor"]
+
+
+def test_add_or_update_event_without_tags(monkeypatch):
+    """
+    Test add_or_update_event does not include tags in payload when not provided.
+    """
+    captured_data = {}
+
+    async def fake_post_request(*_args, **kwargs):
+        captured_data.update(kwargs.get("data", {}))
+        return {
+            "id": "e789",
+            "start_date_local": "2024-01-25T00:00:00",
+            "category": "WORKOUT",
+            "name": "No Tags Workout",
+            "type": "Run",
+        }
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_post_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.events.make_intervals_request", fake_post_request
+    )
+    result = asyncio.run(
+        add_or_update_event(
+            athlete_id="i1",
+            start_date="2024-01-25",
+            name="No Tags Workout",
+            workout_type="Run",
+        )
+    )
+    assert "Successfully created event:" in result
+    assert "tags" not in captured_data


### PR DESCRIPTION
## Summary

Adds support for the Intervals.icu `tags` field when creating or updating events via the `add_or_update_event` tool.

- Tags are passed as a list of strings (e.g., `["sweet-spot", "indoor"]`) matching the API format
- Tags appear as clickable hashtags in the Intervals.icu calendar UI

## Example usage

```python
add_or_update_event(
    name="Tempo Intervals",
    workout_type="Ride",
    start_date="2025-12-15",
    tags=["tempo", "indoor", "trainer"]
)
```

## Test plan

- Unit tests for `add_or_update_event` with tags
- Unit test verifying tags are omitted from payload when not provided
- All existing tests pass
- Linter passes
