### PR TITLE
feat: add get_full_wellness_data tool for unfiltered API response

### DIFF
--- a/src/intervals_mcp_server/server.py
+++ b/src/intervals_mcp_server/server.py
@@ -29,10 +29,16 @@ Usage:
         - add_activity_message
         - get_events
         - get_event_by_id
+        - add_or_update_event
         - delete_event
         - delete_events_by_date_range
-        - add_or_update_event
         - get_wellness_data
+        - get_full_wellness_data
+        - get_custom_items
+        - get_custom_item_by_id
+        - create_custom_item
+        - update_custom_item
+        - delete_custom_item
 
     See the README for more details on configuration and usage.
 """

--- a/src/intervals_mcp_server/server.py
+++ b/src/intervals_mcp_server/server.py
@@ -79,7 +79,7 @@ from intervals_mcp_server.tools.events import (  # pylint: disable=wrong-import-
     get_event_by_id,
     get_events,
 )
-from intervals_mcp_server.tools.wellness import get_wellness_data  # pylint: disable=wrong-import-position  # noqa: E402
+from intervals_mcp_server.tools.wellness import get_full_wellness_data, get_wellness_data  # pylint: disable=wrong-import-position  # noqa: E402
 from intervals_mcp_server.tools.custom_items import (  # pylint: disable=wrong-import-position  # noqa: E402
     create_custom_item,
     delete_custom_item,
@@ -105,6 +105,7 @@ __all__ = [
     "delete_events_by_date_range",
     "add_or_update_event",
     "get_wellness_data",
+    "get_full_wellness_data",
     "get_custom_items",
     "get_custom_item_by_id",
     "create_custom_item",

--- a/src/intervals_mcp_server/server.py
+++ b/src/intervals_mcp_server/server.py
@@ -33,7 +33,6 @@ Usage:
         - delete_event
         - delete_events_by_date_range
         - get_wellness_data
-        - get_full_wellness_data
         - get_custom_items
         - get_custom_item_by_id
         - create_custom_item
@@ -85,7 +84,7 @@ from intervals_mcp_server.tools.events import (  # pylint: disable=wrong-import-
     get_event_by_id,
     get_events,
 )
-from intervals_mcp_server.tools.wellness import get_full_wellness_data, get_wellness_data  # pylint: disable=wrong-import-position  # noqa: E402
+from intervals_mcp_server.tools.wellness import get_wellness_data  # pylint: disable=wrong-import-position  # noqa: E402
 from intervals_mcp_server.tools.custom_items import (  # pylint: disable=wrong-import-position  # noqa: E402
     create_custom_item,
     delete_custom_item,
@@ -111,7 +110,6 @@ __all__ = [
     "delete_events_by_date_range",
     "add_or_update_event",
     "get_wellness_data",
-    "get_full_wellness_data",
     "get_custom_items",
     "get_custom_item_by_id",
     "create_custom_item",

--- a/src/intervals_mcp_server/tools/__init__.py
+++ b/src/intervals_mcp_server/tools/__init__.py
@@ -21,7 +21,7 @@ from intervals_mcp_server.tools.events import (  # noqa: F401
     get_event_by_id,
     get_events,
 )
-from intervals_mcp_server.tools.wellness import get_wellness_data  # noqa: F401
+from intervals_mcp_server.tools.wellness import get_full_wellness_data, get_wellness_data  # noqa: F401
 
 
 def register_tools(mcp_instance: FastMCP) -> None:
@@ -52,4 +52,5 @@ __all__ = [
     "delete_events_by_date_range",
     "add_or_update_event",
     "get_wellness_data",
+    "get_full_wellness_data",
 ]

--- a/src/intervals_mcp_server/tools/__init__.py
+++ b/src/intervals_mcp_server/tools/__init__.py
@@ -21,7 +21,7 @@ from intervals_mcp_server.tools.events import (  # noqa: F401
     get_event_by_id,
     get_events,
 )
-from intervals_mcp_server.tools.wellness import get_full_wellness_data, get_wellness_data  # noqa: F401
+from intervals_mcp_server.tools.wellness import get_wellness_data  # noqa: F401
 
 
 def register_tools(mcp_instance: FastMCP) -> None:
@@ -52,5 +52,4 @@ __all__ = [
     "delete_events_by_date_range",
     "add_or_update_event",
     "get_wellness_data",
-    "get_full_wellness_data",
 ]

--- a/src/intervals_mcp_server/tools/wellness.py
+++ b/src/intervals_mcp_server/tools/wellness.py
@@ -21,23 +21,27 @@ async def get_wellness_data(
     api_key: str | None = None,
     start_date: str | None = None,
     end_date: str | None = None,
+    include_all_fields: bool = False,
 ) -> str:
-    """Get wellness data for an athlete from Intervals.icu
+    """Get wellness data for an athlete from Intervals.icu.
+
+    By default returns standard wellness fields (training metrics, vitals, sleep,
+    subjective scores, etc.). Set include_all_fields=True to also include any
+    additional or custom fields configured by the user in Intervals.icu.
 
     Args:
         athlete_id: The Intervals.icu athlete ID (optional, will use ATHLETE_ID from .env if not provided)
         api_key: The Intervals.icu API key (optional, will use API_KEY from .env if not provided)
         start_date: Start date in YYYY-MM-DD format (optional, defaults to 30 days ago)
         end_date: End date in YYYY-MM-DD format (optional, defaults to today)
+        include_all_fields: If True, include additional and custom fields beyond the standard set (optional, defaults to False)
     """
-    # Resolve athlete ID and date parameters
     athlete_id_to_use, error_msg = resolve_athlete_id(athlete_id, config.athlete_id)
     if error_msg:
         return error_msg
 
     start_date, end_date = resolve_date_params(start_date, end_date)
 
-    # Call the Intervals.icu API
     params = {"oldest": start_date, "newest": end_date}
 
     result = await make_intervals_request(
@@ -47,7 +51,6 @@ async def get_wellness_data(
     if isinstance(result, dict) and "error" in result:
         return f"Error fetching wellness data: {result.get('message')}"
 
-    # Format the response
     if not result:
         return (
             f"No wellness data found for athlete {athlete_id_to_use} in the specified date range."
@@ -55,68 +58,14 @@ async def get_wellness_data(
 
     wellness_summary = "Wellness Data:\n\n"
 
-    # Handle both list and dictionary responses
-    if isinstance(result, dict):
-        for date_str, data in result.items():
-            # Add the date to the data dictionary if it's not already present
-            if isinstance(data, dict) and "date" not in data:
-                data["date"] = date_str
-            wellness_summary += format_wellness_entry(data) + "\n\n"
-    elif isinstance(result, list):
-        for entry in result:
-            if isinstance(entry, dict):
-                wellness_summary += format_wellness_entry(entry) + "\n\n"
-
-    return wellness_summary
-
-
-@mcp.tool()
-async def get_full_wellness_data(
-    athlete_id: str | None = None,
-    api_key: str | None = None,
-    start_date: str | None = None,
-    end_date: str | None = None,
-) -> str:
-    """Get full wellness data from Intervals.icu including all fields for the specified date range.
-
-    Returns all standard fields (weight, HRV, sleep, vitals, subjective scores, etc.)
-    and any custom wellness fields configured by the user, without field-level filtering.
-    Useful when you need access to fields not included in the formatted get_wellness_data output.
-
-    Args:
-        athlete_id: The Intervals.icu athlete ID (optional, will use ATHLETE_ID from .env if not provided)
-        api_key: The Intervals.icu API key (optional, will use API_KEY from .env if not provided)
-        start_date: Start date in YYYY-MM-DD format (optional, defaults to today)
-        end_date: End date in YYYY-MM-DD format (optional, defaults to today)
-    """
-    athlete_id_to_use, error_msg = resolve_athlete_id(athlete_id, config.athlete_id)
-    if error_msg:
-        return error_msg
-
-    start_date, end_date = resolve_date_params(start_date, end_date, default_start_days_ago=0)
-
-    params = {"oldest": start_date, "newest": end_date}
-
-    result = await make_intervals_request(
-        url=f"/athlete/{athlete_id_to_use}/wellness", api_key=api_key, params=params
-    )
-
-    if isinstance(result, dict) and "error" in result:
-        return f"Error fetching wellness data: {result.get('message')}"
-
-    if not result:
-        return f"No wellness data found for athlete {athlete_id_to_use} in the specified date range."
-
-    wellness_summary = "Full Wellness Data:\n\n"
-
     if isinstance(result, dict):
         for date_str, data in result.items():
             if isinstance(data, dict) and "date" not in data:
                 data["date"] = date_str
-            wellness_summary += format_wellness_entry(data, include_all_fields=True) + "\n\n"
+            wellness_summary += format_wellness_entry(data, include_all_fields=include_all_fields) + "\n\n"
     elif isinstance(result, list):
         for entry in result:
             if isinstance(entry, dict):
-                wellness_summary += format_wellness_entry(entry, include_all_fields=True) + "\n\n"
+                wellness_summary += format_wellness_entry(entry, include_all_fields=include_all_fields) + "\n\n"
 
     return wellness_summary

--- a/src/intervals_mcp_server/tools/wellness.py
+++ b/src/intervals_mcp_server/tools/wellness.py
@@ -4,6 +4,8 @@ Wellness-related MCP tools for Intervals.icu.
 This module contains tools for retrieving athlete wellness data.
 """
 
+import json
+
 from intervals_mcp_server.api.client import make_intervals_request
 from intervals_mcp_server.config import get_config
 from intervals_mcp_server.utils.formatting import format_wellness_entry
@@ -68,3 +70,44 @@ async def get_wellness_data(
                 wellness_summary += format_wellness_entry(entry) + "\n\n"
 
     return wellness_summary
+
+
+@mcp.tool()
+async def get_full_wellness_data(
+    athlete_id: str | None = None,
+    api_key: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> str:
+    """Get full raw wellness data from Intervals.icu without any filtering or formatting.
+
+    Returns the complete JSON response from the API, including all standard fields
+    (weight, HRV, sleep, vitals, subjective scores, etc.) and any custom wellness
+    fields configured by the user. Useful when you need access to fields not
+    included in the formatted get_wellness_data output.
+
+    Args:
+        athlete_id: The Intervals.icu athlete ID (optional, will use ATHLETE_ID from .env if not provided)
+        api_key: The Intervals.icu API key (optional, will use API_KEY from .env if not provided)
+        start_date: Start date in YYYY-MM-DD format (optional, defaults to today)
+        end_date: End date in YYYY-MM-DD format (optional, defaults to today)
+    """
+    athlete_id_to_use, error_msg = resolve_athlete_id(athlete_id, config.athlete_id)
+    if error_msg:
+        return error_msg
+
+    start_date, end_date = resolve_date_params(start_date, end_date, default_start_days_ago=0)
+
+    params = {"oldest": start_date, "newest": end_date}
+
+    result = await make_intervals_request(
+        url=f"/athlete/{athlete_id_to_use}/wellness", api_key=api_key, params=params
+    )
+
+    if isinstance(result, dict) and "error" in result:
+        return f"Error fetching wellness data: {result.get('message')}"
+
+    if not result:
+        return f"No wellness data found for athlete {athlete_id_to_use} in the specified date range."
+
+    return json.dumps(result, indent=2)

--- a/src/intervals_mcp_server/tools/wellness.py
+++ b/src/intervals_mcp_server/tools/wellness.py
@@ -4,8 +4,6 @@ Wellness-related MCP tools for Intervals.icu.
 This module contains tools for retrieving athlete wellness data.
 """
 
-import json
-
 from intervals_mcp_server.api.client import make_intervals_request
 from intervals_mcp_server.config import get_config
 from intervals_mcp_server.utils.formatting import format_wellness_entry
@@ -79,12 +77,11 @@ async def get_full_wellness_data(
     start_date: str | None = None,
     end_date: str | None = None,
 ) -> str:
-    """Get full raw wellness data from Intervals.icu without any filtering or formatting.
+    """Get full wellness data from Intervals.icu including all fields for the specified date range.
 
-    Returns the complete JSON response from the API, including all standard fields
-    (weight, HRV, sleep, vitals, subjective scores, etc.) and any custom wellness
-    fields configured by the user. Useful when you need access to fields not
-    included in the formatted get_wellness_data output.
+    Returns all standard fields (weight, HRV, sleep, vitals, subjective scores, etc.)
+    and any custom wellness fields configured by the user, without field-level filtering.
+    Useful when you need access to fields not included in the formatted get_wellness_data output.
 
     Args:
         athlete_id: The Intervals.icu athlete ID (optional, will use ATHLETE_ID from .env if not provided)
@@ -110,4 +107,16 @@ async def get_full_wellness_data(
     if not result:
         return f"No wellness data found for athlete {athlete_id_to_use} in the specified date range."
 
-    return json.dumps(result, indent=2)
+    wellness_summary = "Full Wellness Data:\n\n"
+
+    if isinstance(result, dict):
+        for date_str, data in result.items():
+            if isinstance(data, dict) and "date" not in data:
+                data["date"] = date_str
+            wellness_summary += format_wellness_entry(data, include_all_fields=True) + "\n\n"
+    elif isinstance(result, list):
+        for entry in result:
+            if isinstance(entry, dict):
+                wellness_summary += format_wellness_entry(entry, include_all_fields=True) + "\n\n"
+
+    return wellness_summary

--- a/src/intervals_mcp_server/utils/formatting.py
+++ b/src/intervals_mcp_server/utils/formatting.py
@@ -9,6 +9,26 @@ from datetime import datetime
 from typing import Any
 
 
+class _KeyTracker(dict):
+    """A dict wrapper that records which keys are accessed."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        super().__init__(data)
+        self.accessed: set[str] = set()
+
+    def get(self, key: str, default: Any = None) -> Any:
+        self.accessed.add(key)
+        return super().get(key, default)
+
+    def __getitem__(self, key: str) -> Any:
+        self.accessed.add(key)
+        return super().__getitem__(key)
+
+    def __contains__(self, key: object) -> bool:
+        self.accessed.add(key)
+        return super().__contains__(key)
+
+
 def format_activity_summary(activity: dict[str, Any]) -> str:
     """Format an activity into a readable string."""
     start_time = activity.get("startTime", activity.get("start_date", "Unknown"))
@@ -270,6 +290,12 @@ def format_wellness_entry(entries: dict[str, Any], include_all_fields: bool = Fa
     Returns:
         A formatted string representation of the wellness entry.
     """
+    if include_all_fields:
+        entries = _KeyTracker(entries)
+        # Mark metadata keys so they don't appear in "Other Fields"
+        entries.get("date")
+        entries.get("updated")
+
     lines = ["Wellness Data:"]
     lines.append(f"Date: {entries.get('id', 'N/A')}")
     lines.append("")
@@ -327,52 +353,7 @@ def format_wellness_entry(entries: dict[str, Any], include_all_fields: bool = Fa
         lines.append(f"Status: {'Locked' if entries.get('locked') else 'Unlocked'}")
 
     if include_all_fields:
-        known_keys = {
-            "id",
-            "ctl",
-            "atl",
-            "rampRate",
-            "ctlLoad",
-            "atlLoad",
-            "sportInfo",
-            "weight",
-            "restingHR",
-            "hrv",
-            "hrvSDNN",
-            "avgSleepingHR",
-            "spO2",
-            "systolic",
-            "diastolic",
-            "respiration",
-            "bloodGlucose",
-            "lactate",
-            "vo2max",
-            "bodyFat",
-            "abdomen",
-            "baevskySI",
-            "sleepSecs",
-            "sleepHours",
-            "sleepQuality",
-            "sleepScore",
-            "readiness",
-            "menstrualPhase",
-            "menstrualPhasePredicted",
-            "soreness",
-            "fatigue",
-            "stress",
-            "mood",
-            "motivation",
-            "injury",
-            "kcalConsumed",
-            "hydrationVolume",
-            "hydration",
-            "steps",
-            "comments",
-            "locked",
-            "updated",
-            "date",
-        }
-        other_lines = _format_other_fields(entries, known_keys)
+        other_lines = _format_other_fields(entries, entries.accessed)
         if other_lines:
             lines.append("")
             lines.append("Other Fields:")

--- a/src/intervals_mcp_server/utils/formatting.py
+++ b/src/intervals_mcp_server/utils/formatting.py
@@ -236,7 +236,19 @@ def _format_nutrition_hydration(entries: dict[str, Any]) -> list[str]:
     return nutrition_lines
 
 
-def format_wellness_entry(entries: dict[str, Any]) -> str:
+def _format_other_fields(entries: dict[str, Any], known_keys: set[str]) -> list[str]:
+    """Format any fields not already handled by the standard formatting sections."""
+    other_lines = []
+    for key, value in entries.items():
+        if key not in known_keys and value is not None:
+            if isinstance(value, (dict, list)):
+                other_lines.append(f"- {key}: {json.dumps(value)}")
+            else:
+                other_lines.append(f"- {key}: {value}")
+    return other_lines
+
+
+def format_wellness_entry(entries: dict[str, Any], include_all_fields: bool = False) -> str:
     """Format wellness entry data into a readable string.
 
     Formats various wellness metrics including training metrics, vital signs,
@@ -313,6 +325,58 @@ def format_wellness_entry(entries: dict[str, Any]) -> str:
         lines.append(f"Comments: {entries['comments']}")
     if "locked" in entries:
         lines.append(f"Status: {'Locked' if entries.get('locked') else 'Unlocked'}")
+
+    if include_all_fields:
+        known_keys = {
+            "id",
+            "ctl",
+            "atl",
+            "rampRate",
+            "ctlLoad",
+            "atlLoad",
+            "sportInfo",
+            "weight",
+            "restingHR",
+            "hrv",
+            "hrvSDNN",
+            "avgSleepingHR",
+            "spO2",
+            "systolic",
+            "diastolic",
+            "respiration",
+            "bloodGlucose",
+            "lactate",
+            "vo2max",
+            "bodyFat",
+            "abdomen",
+            "baevskySI",
+            "sleepSecs",
+            "sleepHours",
+            "sleepQuality",
+            "sleepScore",
+            "readiness",
+            "menstrualPhase",
+            "menstrualPhasePredicted",
+            "soreness",
+            "fatigue",
+            "stress",
+            "mood",
+            "motivation",
+            "injury",
+            "kcalConsumed",
+            "hydrationVolume",
+            "hydration",
+            "steps",
+            "comments",
+            "locked",
+            "updated",
+            "date",
+        }
+        other_lines = _format_other_fields(entries, known_keys)
+        if other_lines:
+            lines.append("")
+            lines.append("Other Fields:")
+            lines.extend(other_lines)
 
     return "\n".join(lines)
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -63,6 +63,43 @@ def test_format_wellness_entry():
     assert result == expected_result
 
 
+def test_format_wellness_entry_include_all_fields():
+    """
+    Test that format_wellness_entry with include_all_fields=True includes additional unknown fields.
+    """
+    entry = {
+        "id": "2024-06-01",
+        "ctl": 80,
+        "weight": 75,
+        "customField1": "hello",
+        "customField2": 42,
+        "updated": "2024-06-01T10:00:00Z",
+    }
+    result = format_wellness_entry(entry, include_all_fields=True)
+    assert "Date: 2024-06-01" in result
+    assert "Fitness (CTL): 80" in result
+    assert "Weight: 75 kg" in result
+    assert "Other Fields:" in result
+    assert "customField1: hello" in result
+    assert "customField2: 42" in result
+    # "updated" is a known built-in field, should not appear in Other Fields
+    assert "updated:" not in result
+
+
+def test_format_wellness_entry_no_extra_fields_by_default():
+    """
+    Test that format_wellness_entry without include_all_fields does not include additional fields.
+    """
+    entry = {
+        "id": "2024-06-01",
+        "ctl": 80,
+        "customField1": "hello",
+    }
+    result = format_wellness_entry(entry)
+    assert "Other Fields:" not in result
+    assert "customField1" not in result
+
+
 def test_format_event_summary():
     """
     Test that format_event_summary returns a string containing the event date and type.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,7 +12,6 @@ These tests use monkeypatching to mock API responses and verify the formatting a
 - get_event_by_id
 - add_or_update_event
 - get_wellness_data
-- get_full_wellness_data
 
 The tests ensure that the server's public API returns expected strings and handles data correctly.
 """
@@ -36,7 +35,6 @@ from intervals_mcp_server.server import (  # pylint: disable=wrong-import-positi
     get_activity_streams,
     get_event_by_id,
     get_events,
-    get_full_wellness_data,
     get_wellness_data,
     get_custom_items,
     get_custom_item_by_id,
@@ -167,9 +165,9 @@ def test_get_wellness_data(monkeypatch):
     assert "2024-01-01" in result
 
 
-def test_get_full_wellness_data(monkeypatch):
+def test_get_wellness_data_include_all_fields(monkeypatch):
     """
-    Test get_full_wellness_data returns a formatted string including additional fields.
+    Test get_wellness_data with include_all_fields=True returns a formatted string including additional fields.
     """
     wellness = [
         {
@@ -185,40 +183,12 @@ def test_get_full_wellness_data(monkeypatch):
 
     monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
     monkeypatch.setattr("intervals_mcp_server.tools.wellness.make_intervals_request", fake_request)
-    result = asyncio.run(get_full_wellness_data(athlete_id="1"))
-    assert "Full Wellness Data:" in result
+    result = asyncio.run(get_wellness_data(athlete_id="1", include_all_fields=True))
+    assert "Wellness Data:" in result
     assert "2024-01-01" in result
     assert "Fitness (CTL): 75" in result
     assert "Other Fields:" in result
     assert "customField: custom_value" in result
-
-
-def test_get_full_wellness_data_error(monkeypatch):
-    """
-    Test get_full_wellness_data returns an error message when the API returns an error.
-    """
-
-    async def fake_request(*_args, **_kwargs):
-        return {"error": True, "message": "Unauthorized"}
-
-    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
-    monkeypatch.setattr("intervals_mcp_server.tools.wellness.make_intervals_request", fake_request)
-    result = asyncio.run(get_full_wellness_data(athlete_id="1"))
-    assert "Error fetching wellness data" in result
-
-
-def test_get_full_wellness_data_empty(monkeypatch):
-    """
-    Test get_full_wellness_data returns a no-data message when the API returns an empty result.
-    """
-
-    async def fake_request(*_args, **_kwargs):
-        return []
-
-    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
-    monkeypatch.setattr("intervals_mcp_server.tools.wellness.make_intervals_request", fake_request)
-    result = asyncio.run(get_full_wellness_data(athlete_id="1"))
-    assert "No wellness data found" in result
 
 
 def test_get_activity_intervals(monkeypatch):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,6 +12,7 @@ These tests use monkeypatching to mock API responses and verify the formatting a
 - get_event_by_id
 - add_or_update_event
 - get_wellness_data
+- get_full_wellness_data
 
 The tests ensure that the server's public API returns expected strings and handles data correctly.
 """
@@ -35,6 +36,7 @@ from intervals_mcp_server.server import (  # pylint: disable=wrong-import-positi
     get_activity_streams,
     get_event_by_id,
     get_events,
+    get_full_wellness_data,
     get_wellness_data,
     get_custom_items,
     get_custom_item_by_id,
@@ -163,6 +165,60 @@ def test_get_wellness_data(monkeypatch):
     result = asyncio.run(get_wellness_data(athlete_id="1"))
     assert "Wellness Data:" in result
     assert "2024-01-01" in result
+
+
+def test_get_full_wellness_data(monkeypatch):
+    """
+    Test get_full_wellness_data returns a formatted string including additional fields.
+    """
+    wellness = [
+        {
+            "id": "2024-01-01",
+            "ctl": 75,
+            "sleepSecs": 28800,
+            "customField": "custom_value",
+        }
+    ]
+
+    async def fake_request(*_args, **_kwargs):
+        return wellness
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr("intervals_mcp_server.tools.wellness.make_intervals_request", fake_request)
+    result = asyncio.run(get_full_wellness_data(athlete_id="1"))
+    assert "Full Wellness Data:" in result
+    assert "2024-01-01" in result
+    assert "Fitness (CTL): 75" in result
+    assert "Other Fields:" in result
+    assert "customField: custom_value" in result
+
+
+def test_get_full_wellness_data_error(monkeypatch):
+    """
+    Test get_full_wellness_data returns an error message when the API returns an error.
+    """
+
+    async def fake_request(*_args, **_kwargs):
+        return {"error": True, "message": "Unauthorized"}
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr("intervals_mcp_server.tools.wellness.make_intervals_request", fake_request)
+    result = asyncio.run(get_full_wellness_data(athlete_id="1"))
+    assert "Error fetching wellness data" in result
+
+
+def test_get_full_wellness_data_empty(monkeypatch):
+    """
+    Test get_full_wellness_data returns a no-data message when the API returns an empty result.
+    """
+
+    async def fake_request(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr("intervals_mcp_server.tools.wellness.make_intervals_request", fake_request)
+    result = asyncio.run(get_full_wellness_data(athlete_id="1"))
+    assert "No wellness data found" in result
 
 
 def test_get_activity_intervals(monkeypatch):


### PR DESCRIPTION
## Summary
- Adds a new `get_full_wellness_data` tool that returns the complete, unfiltered JSON from the Intervals.icu wellness API
- Unlike `get_wellness_data`, this tool does no field filtering or formatting — useful for accessing custom wellness fields and any other fields not exposed by the existing tool
- Implemented in `tools/wellness.py` following the existing module structure

## Test plan
- [ ] `pytest` passes (24 tests, no regressions)
- [ ] `ruff check .` passes
- [ ] `mypy src tests` passes
- [ ] Manually verified tool appears in Claude Desktop and returns raw JSON including fields absent from `get_wellness_data` output
