### PR TITLE
docs: document include_all_fields param in format_wellness_entry

### DIFF
--- a/src/intervals_mcp_server/utils/formatting.py
+++ b/src/intervals_mcp_server/utils/formatting.py
@@ -286,6 +286,8 @@ def format_wellness_entry(entries: dict[str, Any], include_all_fields: bool = Fa
             - Nutrition: kcalConsumed, hydrationVolume, hydration
             - Activity: steps
             - Other: comments, locked, date
+        include_all_fields: If True, any fields not covered by the standard
+            sections are appended under an "Other Fields" heading (default False).
 
     Returns:
         A formatted string representation of the wellness entry.


### PR DESCRIPTION
## Summary
- The `include_all_fields` parameter added in #97 was missing from the `format_wellness_entry` docstring. This adds a one-line description consistent with the existing `Args` section style.

## Test plan
- No code change — docstring only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)