### PR TITLE
feat: add pace and swim pace value units to ValueUnits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,3 +115,8 @@ asyncio_default_fixture_loop_scope = "function"
 
 [tool.uv]
 index-url = "https://pypi.org/simple"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.1",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,8 +115,3 @@ asyncio_default_fixture_loop_scope = "function"
 
 [tool.uv]
 index-url = "https://pypi.org/simple"
-
-[dependency-groups]
-dev = [
-    "pytest>=9.0.1",
-]

--- a/src/intervals_mcp_server/utils/types.py
+++ b/src/intervals_mcp_server/utils/types.py
@@ -89,6 +89,10 @@ class ValueUnits(Enum):
     WATTS = "w"
     PERCENT_FTP = "%ftp"
     CADENCE = "cadence"
+    MINS_KM = "MINS_KM"
+    MINS_MILE = "MINS_MILE"
+    SECS_100M = "SECS_100M"
+    SECS_500M = "SECS_500M"
 
 
 class TransportAliases(StrEnum):

--- a/tests/test_value.py
+++ b/tests/test_value.py
@@ -4,7 +4,10 @@ Unit tests for the Value dataclass in intervals_mcp_server.utils.types.
 These tests verify that the Value dataclass correctly handles:
 - String formatting for percent FTP units
 - Ramp intervals (start/end values)
+- Deserialisation of pace/swim-pace unit strings returned by the Intervals.icu API
 """
+
+import pytest
 
 from intervals_mcp_server.utils.types import Value, ValueUnits
 
@@ -19,3 +22,17 @@ def test_str_ramp_percent_ftp():
     """Test formatting ramp intervals with percentage FTP."""
     val = Value(start=65, end=85, units=ValueUnits.PERCENT_FTP)
     assert str(val) == "65%-85% ftp"
+
+
+@pytest.mark.parametrize("unit_str,expected_enum", [
+    ("MINS_KM", ValueUnits.MINS_KM),
+    ("MINS_MILE", ValueUnits.MINS_MILE),
+    ("SECS_100M", ValueUnits.SECS_100M),
+    ("SECS_500M", ValueUnits.SECS_500M),
+])
+def test_pace_units_deserialise_from_api_string(unit_str, expected_enum):
+    """Pace/swim-pace unit strings returned by the Intervals.icu API must round-trip
+    through Value.from_dict without raising ValueError.  This test would fail if any
+    of these unit strings were missing from the ValueUnits enum."""
+    val = Value.from_dict({"value": 5.0, "units": unit_str})
+    assert val.units == expected_enum

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -352,6 +352,11 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "hatch", marker = "extra == 'dev'" },
@@ -366,6 +371,9 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.1" }]
 
 [[package]]
 name = "jaraco-classes"


### PR DESCRIPTION
## What changed

Added four missing pace/swim-pace unit variants to the `ValueUnits` enum in `src/intervals_mcp_server/utils/types.py`:

- `MINS_KM` — running pace in minutes per kilometre
- `MINS_MILE` — running pace in minutes per mile
- `SECS_100M` — swim pace in seconds per 100 metres
- `SECS_500M` — rowing/swim pace in seconds per 500 metres

## Why

These unit strings are returned by the Intervals.icu API for pace-based workout targets but were not present in the enum, causing deserialisation failures when encountering activities that use these units.

## Reviewer notes

No logic changes — enum values only. Existing tests are unaffected.