### PR TITLE
feat: resolve gear names via /athlete/{id}/gear and add get_gear_list…

### DIFF
--- a/src/intervals_mcp_server/server.py
+++ b/src/intervals_mcp_server/server.py
@@ -85,6 +85,7 @@ from intervals_mcp_server.tools.events import (  # pylint: disable=wrong-import-
     get_event_by_id,
     get_events,
 )
+from intervals_mcp_server.tools.gear import get_gear_list  # pylint: disable=wrong-import-position  # noqa: E402
 from intervals_mcp_server.tools.wellness import get_wellness_data  # pylint: disable=wrong-import-position  # noqa: E402
 from intervals_mcp_server.tools.power_curves import get_athlete_power_curves  # pylint: disable=wrong-import-position  # noqa: E402
 from intervals_mcp_server.tools.custom_items import (  # pylint: disable=wrong-import-position  # noqa: E402

--- a/src/intervals_mcp_server/tools/__init__.py
+++ b/src/intervals_mcp_server/tools/__init__.py
@@ -31,6 +31,7 @@ from intervals_mcp_server.tools.custom_items import (  # noqa: F401
 from intervals_mcp_server.tools.power_curves import (  # noqa: F401
     get_athlete_power_curves,
 )
+from intervals_mcp_server.tools.gear import get_gear_list  # noqa: F401
 from intervals_mcp_server.tools.wellness import get_wellness_data  # noqa: F401
 
 
@@ -67,5 +68,6 @@ __all__ = [
     "update_custom_item",
     "delete_custom_item",
     "get_athlete_power_curves",
+    "get_gear_list",
     "get_wellness_data",
 ]

--- a/src/intervals_mcp_server/tools/activities.py
+++ b/src/intervals_mcp_server/tools/activities.py
@@ -9,6 +9,10 @@ from typing import Any
 
 from intervals_mcp_server.api.client import make_intervals_request
 from intervals_mcp_server.config import get_config
+from intervals_mcp_server.tools.gear import (
+    resolve_gear_for_activity,
+    resolve_gear_for_activities,
+)
 from intervals_mcp_server.utils.formatting import format_activity_message, format_activity_summary, format_intervals
 from intervals_mcp_server.utils.validation import resolve_athlete_id, resolve_date_params
 
@@ -163,6 +167,11 @@ async def get_activities(  # pylint: disable=too-many-arguments,too-many-return-
     # Limit to requested count
     activities = activities[:limit]
 
+    # Resolve gear names (in-place injection of `_resolved_gear_name`)
+    await resolve_gear_for_activities(
+        activities, athlete_id=athlete_id_to_use, api_key=api_key
+    )
+
     return _format_activities_response(activities, athlete_id_to_use, include_unnamed)
 
 
@@ -189,6 +198,9 @@ async def get_activity_details(activity_id: str, api_key: str | None = None) -> 
     activity_data = result[0] if isinstance(result, list) and result else result
     if not isinstance(activity_data, dict):
         return f"Invalid activity format for activity {activity_id}."
+
+    # Resolve gear name (uses configured athlete_id via ATHLETE_ID env var)
+    await resolve_gear_for_activity(activity_data, api_key=api_key)
 
     # Return a more detailed view of the activity
     detailed_view = format_activity_summary(activity_data)

--- a/src/intervals_mcp_server/tools/gear.py
+++ b/src/intervals_mcp_server/tools/gear.py
@@ -2,8 +2,8 @@
 Gear-related MCP tools for Intervals.icu.
 
 This module provides:
-- A module-level cache of the athlete's gear list (bikes, shoes, etc.) to avoid
-  hitting the /athlete/{id}/gear endpoint on every activity lookup.
+- A module-level cache of the athlete's raw gear catalog (bikes, shoes, etc.)
+  to avoid hitting the /athlete/{id}/gear endpoint on every activity lookup.
 - A helper to inject the human-readable gear name into an activity dict (under
   `_resolved_gear_name`), which the formatter then displays in the `Gear:` block.
 - A user-facing MCP tool `get_gear_list` so the assistant can discover or
@@ -12,8 +12,9 @@ This module provides:
 Intervals.icu's activity payload includes only the gear ID (e.g. `b16177481`)
 but not the gear name. The gear name lives in a separate endpoint
 `/athlete/{athlete_id}/gear` that returns the full catalog. To avoid an extra
-round-trip per activity, we cache the gear catalog per athlete for the lifetime
-of the MCP server process. Call `get_gear_list` again to bust the cache.
+round-trip per activity, we cache the raw gear catalog per athlete for the
+lifetime of the MCP server process and derive the `{id: name}` lookup from it.
+Call `get_gear_list(refresh=True)` to bust the cache.
 """
 
 from typing import Any
@@ -27,10 +28,9 @@ from intervals_mcp_server.mcp_instance import mcp  # noqa: F401
 
 config = get_config()
 
-# Module-level cache: {athlete_id: {gear_id: gear_name}}.
-# Keyed by athlete_id so the same MCP process can serve multiple athletes,
-# although the typical case is a single athlete via ATHLETE_ID env var.
-_GEAR_CACHE: dict[str, dict[str, str]] = {}
+# Module-level cache of the raw gear catalog per athlete. Single source of
+# truth: the id->name map and the rich listing are both derived from this.
+_GEAR_RAW_CACHE: dict[str, list[dict[str, Any]]] = {}
 
 
 def _extract_gear_id(activity: dict[str, Any]) -> str | None:
@@ -46,44 +46,40 @@ def _extract_gear_id(activity: dict[str, Any]) -> str | None:
     return None
 
 
-async def _fetch_gear_map(
-    athlete_id: str,
-    api_key: str | None = None,
-) -> dict[str, str]:
-    """Fetch the athlete's gear catalog from Intervals.icu and return {id: name}."""
-    result = await make_intervals_request(
-        url=f"/athlete/{athlete_id}/gear", api_key=api_key
-    )
-    gear_map: dict[str, str] = {}
-
-    items: list[Any] = []
+def _items_from_response(result: Any) -> list[dict[str, Any]]:
+    """Normalize the /athlete/{id}/gear response into a list of gear dicts."""
     if isinstance(result, list):
-        items = result
-    elif isinstance(result, dict):
+        return [item for item in result if isinstance(item, dict)]
+    if isinstance(result, dict):
         # Some endpoints wrap the list in a container; pull any list value.
         for value in result.values():
             if isinstance(value, list):
-                items = value
-                break
+                return [item for item in value if isinstance(item, dict)]
+    return []
 
+
+def _derive_gear_map(items: list[dict[str, Any]]) -> dict[str, str]:
+    """Convert a raw gear list into a {gear_id: gear_name} lookup."""
+    gear_map: dict[str, str] = {}
     for item in items:
-        if not isinstance(item, dict):
-            continue
         gid = item.get("id")
         name = item.get("name") or item.get("display_name")
         if gid and name:
             gear_map[str(gid)] = str(name)
-
     return gear_map
 
 
-async def get_gear_map(
+async def get_gear_raw(
     athlete_id: str | None = None,
     api_key: str | None = None,
     *,
     refresh: bool = False,
-) -> dict[str, str]:
-    """Return (and cache) the gear map {gear_id: gear_name} for an athlete.
+) -> list[dict[str, Any]]:
+    """Return (and cache) the raw gear list for an athlete.
+
+    Single source of truth that backs both the id->name map and the rich
+    listing produced by `get_gear_list`. One API call per athlete per process
+    lifetime unless `refresh=True`.
 
     Args:
         athlete_id: Athlete to look up. Defaults to ATHLETE_ID env var via config.
@@ -92,14 +88,28 @@ async def get_gear_map(
     """
     athlete_id_to_use, error_msg = resolve_athlete_id(athlete_id, config.athlete_id)
     if error_msg or not athlete_id_to_use:
-        return {}
+        return []
 
-    if not refresh and athlete_id_to_use in _GEAR_CACHE:
-        return _GEAR_CACHE[athlete_id_to_use]
+    if not refresh and athlete_id_to_use in _GEAR_RAW_CACHE:
+        return _GEAR_RAW_CACHE[athlete_id_to_use]
 
-    gear_map = await _fetch_gear_map(athlete_id_to_use, api_key=api_key)
-    _GEAR_CACHE[athlete_id_to_use] = gear_map
-    return gear_map
+    result = await make_intervals_request(
+        url=f"/athlete/{athlete_id_to_use}/gear", api_key=api_key
+    )
+    items = _items_from_response(result)
+    _GEAR_RAW_CACHE[athlete_id_to_use] = items
+    return items
+
+
+async def get_gear_map(
+    athlete_id: str | None = None,
+    api_key: str | None = None,
+    *,
+    refresh: bool = False,
+) -> dict[str, str]:
+    """Return the {gear_id: gear_name} lookup for an athlete (derived from cache)."""
+    items = await get_gear_raw(athlete_id=athlete_id, api_key=api_key, refresh=refresh)
+    return _derive_gear_map(items)
 
 
 async def resolve_gear_for_activity(
@@ -162,28 +172,14 @@ async def get_gear_list(
     if not athlete_id_to_use:
         return "Error: athlete_id is required (either as argument or via ATHLETE_ID env var)."
 
-    # Fetch + cache via the helper.
-    gear_map = await get_gear_map(
+    # Single fetch path: get_gear_raw consults the cache and only hits the API
+    # on a cold cache or when refresh=True.
+    items = await get_gear_raw(
         athlete_id=athlete_id_to_use, api_key=api_key, refresh=refresh
     )
 
-    if not gear_map:
+    if not items:
         return f"No gear found for athlete {athlete_id_to_use}."
-
-    # For the rich listing, refetch the raw list once so we can include type
-    # and stats. (The cached map only stores id→name.)
-    raw = await make_intervals_request(
-        url=f"/athlete/{athlete_id_to_use}/gear", api_key=api_key
-    )
-
-    items: list[dict[str, Any]] = []
-    if isinstance(raw, list):
-        items = [it for it in raw if isinstance(it, dict)]
-    elif isinstance(raw, dict):
-        for value in raw.values():
-            if isinstance(value, list):
-                items = [it for it in value if isinstance(it, dict)]
-                break
 
     output = f"Gear catalog for athlete {athlete_id_to_use}:\n\n"
     output += f"{'ID':<14} {'Type':<8} {'Name':<32} {'Default':<8} {'Acts':<6} {'Dist (km)':<10} {'Retired':<8}\n"

--- a/src/intervals_mcp_server/tools/gear.py
+++ b/src/intervals_mcp_server/tools/gear.py
@@ -1,0 +1,202 @@
+"""
+Gear-related MCP tools for Intervals.icu.
+
+This module provides:
+- A module-level cache of the athlete's gear list (bikes, shoes, etc.) to avoid
+  hitting the /athlete/{id}/gear endpoint on every activity lookup.
+- A helper to inject the human-readable gear name into an activity dict (under
+  `_resolved_gear_name`), which the formatter then displays in the `Gear:` block.
+- A user-facing MCP tool `get_gear_list` so the assistant can discover or
+  refresh the gear catalog on demand.
+
+Intervals.icu's activity payload includes only the gear ID (e.g. `b16177481`)
+but not the gear name. The gear name lives in a separate endpoint
+`/athlete/{athlete_id}/gear` that returns the full catalog. To avoid an extra
+round-trip per activity, we cache the gear catalog per athlete for the lifetime
+of the MCP server process. Call `get_gear_list` again to bust the cache.
+"""
+
+from typing import Any
+
+from intervals_mcp_server.api.client import make_intervals_request
+from intervals_mcp_server.config import get_config
+from intervals_mcp_server.utils.validation import resolve_athlete_id
+
+# Import mcp instance from shared module for tool registration
+from intervals_mcp_server.mcp_instance import mcp  # noqa: F401
+
+config = get_config()
+
+# Module-level cache: {athlete_id: {gear_id: gear_name}}.
+# Keyed by athlete_id so the same MCP process can serve multiple athletes,
+# although the typical case is a single athlete via ATHLETE_ID env var.
+_GEAR_CACHE: dict[str, dict[str, str]] = {}
+
+
+def _extract_gear_id(activity: dict[str, Any]) -> str | None:
+    """Pull the gear ID out of an activity dict, handling the two known shapes."""
+    gear_raw = activity.get("gear")
+    if isinstance(gear_raw, dict):
+        gear_id = gear_raw.get("id")
+        if gear_id:
+            return str(gear_id)
+    gear_id = activity.get("gear_id")
+    if gear_id:
+        return str(gear_id)
+    return None
+
+
+async def _fetch_gear_map(
+    athlete_id: str,
+    api_key: str | None = None,
+) -> dict[str, str]:
+    """Fetch the athlete's gear catalog from Intervals.icu and return {id: name}."""
+    result = await make_intervals_request(
+        url=f"/athlete/{athlete_id}/gear", api_key=api_key
+    )
+    gear_map: dict[str, str] = {}
+
+    items: list[Any] = []
+    if isinstance(result, list):
+        items = result
+    elif isinstance(result, dict):
+        # Some endpoints wrap the list in a container; pull any list value.
+        for value in result.values():
+            if isinstance(value, list):
+                items = value
+                break
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        gid = item.get("id")
+        name = item.get("name") or item.get("display_name")
+        if gid and name:
+            gear_map[str(gid)] = str(name)
+
+    return gear_map
+
+
+async def get_gear_map(
+    athlete_id: str | None = None,
+    api_key: str | None = None,
+    *,
+    refresh: bool = False,
+) -> dict[str, str]:
+    """Return (and cache) the gear map {gear_id: gear_name} for an athlete.
+
+    Args:
+        athlete_id: Athlete to look up. Defaults to ATHLETE_ID env var via config.
+        api_key: Override the configured API key.
+        refresh: If True, ignore the cache and re-fetch from the API.
+    """
+    athlete_id_to_use, error_msg = resolve_athlete_id(athlete_id, config.athlete_id)
+    if error_msg or not athlete_id_to_use:
+        return {}
+
+    if not refresh and athlete_id_to_use in _GEAR_CACHE:
+        return _GEAR_CACHE[athlete_id_to_use]
+
+    gear_map = await _fetch_gear_map(athlete_id_to_use, api_key=api_key)
+    _GEAR_CACHE[athlete_id_to_use] = gear_map
+    return gear_map
+
+
+async def resolve_gear_for_activity(
+    activity: dict[str, Any],
+    athlete_id: str | None = None,
+    api_key: str | None = None,
+) -> None:
+    """Inject `_resolved_gear_name` into an activity dict if gear info is present.
+
+    Mutates the activity dict in place. Safe to call when gear is absent (no-op).
+    Uses the cached gear map; the first call per athlete triggers a fetch.
+    """
+    gear_id = _extract_gear_id(activity)
+    if not gear_id:
+        return
+
+    gear_map = await get_gear_map(athlete_id=athlete_id, api_key=api_key)
+    name = gear_map.get(gear_id)
+    if name:
+        activity["_resolved_gear_name"] = name
+
+
+async def resolve_gear_for_activities(
+    activities: list[dict[str, Any]],
+    athlete_id: str | None = None,
+    api_key: str | None = None,
+) -> None:
+    """Inject `_resolved_gear_name` into each activity in a list. In-place."""
+    if not activities:
+        return
+    # Pre-warm the cache once, then iterate.
+    _ = await get_gear_map(athlete_id=athlete_id, api_key=api_key)
+    for activity in activities:
+        if isinstance(activity, dict):
+            await resolve_gear_for_activity(
+                activity, athlete_id=athlete_id, api_key=api_key
+            )
+
+
+@mcp.tool()
+async def get_gear_list(
+    athlete_id: str | None = None,
+    api_key: str | None = None,
+    refresh: bool = False,
+) -> str:
+    """Get the gear catalog (bikes, shoes, etc.) for an athlete from Intervals.icu.
+
+    Returns one line per gear item with id, type, name, and basic stats.
+    The result is cached for the MCP process lifetime; pass refresh=True to
+    re-fetch.
+
+    Args:
+        athlete_id: The Intervals.icu athlete ID (optional, will use ATHLETE_ID from .env if not provided)
+        api_key: The Intervals.icu API key (optional, will use API_KEY from .env if not provided)
+        refresh: If True, bypass the cache and re-fetch from the API (default False)
+    """
+    athlete_id_to_use, error_msg = resolve_athlete_id(athlete_id, config.athlete_id)
+    if error_msg:
+        return error_msg
+    if not athlete_id_to_use:
+        return "Error: athlete_id is required (either as argument or via ATHLETE_ID env var)."
+
+    # Fetch + cache via the helper.
+    gear_map = await get_gear_map(
+        athlete_id=athlete_id_to_use, api_key=api_key, refresh=refresh
+    )
+
+    if not gear_map:
+        return f"No gear found for athlete {athlete_id_to_use}."
+
+    # For the rich listing, refetch the raw list once so we can include type
+    # and stats. (The cached map only stores id→name.)
+    raw = await make_intervals_request(
+        url=f"/athlete/{athlete_id_to_use}/gear", api_key=api_key
+    )
+
+    items: list[dict[str, Any]] = []
+    if isinstance(raw, list):
+        items = [it for it in raw if isinstance(it, dict)]
+    elif isinstance(raw, dict):
+        for value in raw.values():
+            if isinstance(value, list):
+                items = [it for it in value if isinstance(it, dict)]
+                break
+
+    output = f"Gear catalog for athlete {athlete_id_to_use}:\n\n"
+    output += f"{'ID':<14} {'Type':<8} {'Name':<32} {'Default':<8} {'Acts':<6} {'Dist (km)':<10} {'Retired':<8}\n"
+    output += f"{'-' * 14} {'-' * 8} {'-' * 32} {'-' * 8} {'-' * 6} {'-' * 10} {'-' * 8}\n"
+    for it in items:
+        gid = str(it.get("id", "?"))
+        gtype = str(it.get("component_type", it.get("type", "?")))
+        name = str(it.get("name", "?"))[:32]
+        default_for = it.get("default_for_type") or it.get("default_for") or ""
+        acts = str(it.get("activities", it.get("activity_count", "?")))
+        dist_m = it.get("distance", 0) or 0
+        dist_km = f"{dist_m / 1000:.1f}" if isinstance(dist_m, (int, float)) else "?"
+        retired = "yes" if it.get("retired") else ""
+        output += f"{gid:<14} {gtype:<8} {name:<32} {str(default_for):<8} {acts:<6} {dist_km:<10} {retired:<8}\n"
+
+    return output

--- a/src/intervals_mcp_server/utils/formatting.py
+++ b/src/intervals_mcp_server/utils/formatting.py
@@ -52,6 +52,26 @@ def format_activity_summary(activity: dict[str, Any]) -> str:
     if isinstance(feel, int):
         feel = f"{feel}/5"
 
+    # Gear (bike, shoes) - ICU activity payloads include the gear ID but not the
+    # gear name (which lives in /athlete/{id}/gear). The tools.gear module
+    # resolves the name and injects it as `_resolved_gear_name` before this
+    # formatter runs. Prefer the resolved name; otherwise fall back to whatever
+    # the raw payload provides (typically just an ID).
+    resolved_name = activity.get("_resolved_gear_name")
+    gear_raw = activity.get("gear")
+    if resolved_name:
+        gear_name = resolved_name
+        if isinstance(gear_raw, dict):
+            gear_id = gear_raw.get("id", activity.get("gear_id", "N/A"))
+        else:
+            gear_id = activity.get("gear_id", "N/A")
+    elif isinstance(gear_raw, dict):
+        gear_name = gear_raw.get("name") or gear_raw.get("display_name") or "N/A"
+        gear_id = gear_raw.get("id", "N/A")
+    else:
+        gear_name = activity.get("gear_name", "N/A")
+        gear_id = activity.get("gear_id", "N/A")
+
     return f"""
 Activity: {activity.get("name", "Unnamed")}
 ID: {activity.get("id", "N/A")}
@@ -116,6 +136,10 @@ Device Info:
 Device: {activity.get("device_name", "N/A")}
 Power Meter: {activity.get("power_meter", "N/A")}
 File Type: {activity.get("file_type", "N/A")}
+
+Gear:
+Name: {gear_name}
+ID: {gear_id}
 """
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -889,6 +889,9 @@ def test_get_activity_details_resolves_gear_name(monkeypatch):
     monkeypatch.setattr(
         "intervals_mcp_server.tools.gear.make_intervals_request", fake_request
     )
+    # get_activity_details does not accept athlete_id; gear resolution falls
+    # back to the configured ATHLETE_ID, which is unset under CI. Provide one.
+    monkeypatch.setattr(gear_module.config, "athlete_id", "1")
 
     result = asyncio.run(get_activity_details(123))
     assert "Activity: Morning Ride" in result

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -36,6 +36,7 @@ from intervals_mcp_server.server import (  # pylint: disable=wrong-import-positi
     get_athlete_power_curves,
     get_event_by_id,
     get_events,
+    get_gear_list,
     get_wellness_data,
     get_custom_items,
     get_custom_item_by_id,
@@ -43,7 +44,13 @@ from intervals_mcp_server.server import (  # pylint: disable=wrong-import-positi
     update_custom_item,
     delete_custom_item,
 )
+from intervals_mcp_server.tools import gear as gear_module  # pylint: disable=wrong-import-position
 from tests.sample_data import INTERVALS_DATA, POWER_CURVES_DATA  # pylint: disable=wrong-import-position
+
+
+def _reset_gear_cache():
+    """Helper to clear the module-level gear cache between tests."""
+    gear_module._GEAR_RAW_CACHE.clear()  # pylint: disable=protected-access
 
 
 def test_get_activities(monkeypatch):
@@ -742,3 +749,200 @@ def test_create_custom_item_with_invalid_json_content(monkeypatch):
         )
     )
     assert "Error: content must be valid JSON when passed as a string." in result
+
+
+# ---------------------------------------------------------------------------
+# Gear tools
+# ---------------------------------------------------------------------------
+
+
+def test_get_gear_list(monkeypatch):
+    """
+    Test get_gear_list returns a formatted catalog with id, type, name and stats.
+    """
+    _reset_gear_cache()
+
+    sample_gear = [
+        {
+            "id": "b1",
+            "type": "Bike",
+            "name": "Litening Air",
+            "default_for_type": "Ride",
+            "activities": 100,
+            "distance": 4_155_700,
+            "retired": False,
+        },
+        {
+            "id": "b2",
+            "type": "Bike",
+            "name": "Retired bike",
+            "activities": 50,
+            "distance": 2_000_000,
+            "retired": True,
+        },
+    ]
+
+    async def fake_request(*_args, **_kwargs):
+        return sample_gear
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.gear.make_intervals_request", fake_request
+    )
+
+    result = asyncio.run(get_gear_list(athlete_id="i1"))
+
+    assert "Gear catalog for athlete i1:" in result
+    assert "Litening Air" in result
+    assert "b1" in result
+    assert "Retired bike" in result
+    assert "yes" in result  # retired flag rendered
+    assert "Ride" in result  # default_for_type rendered
+
+
+def test_get_gear_list_empty(monkeypatch):
+    """
+    Test get_gear_list returns an informative message when no gear is configured.
+    """
+    _reset_gear_cache()
+
+    async def fake_request(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.gear.make_intervals_request", fake_request
+    )
+
+    result = asyncio.run(get_gear_list(athlete_id="i1"))
+    assert "No gear found" in result
+
+
+def test_get_gear_list_cache_and_refresh(monkeypatch):
+    """
+    Test that get_gear_list caches the catalog and that refresh=True busts the cache.
+    """
+    _reset_gear_cache()
+
+    call_count = {"n": 0}
+    sample_gear = [
+        {
+            "id": "b1",
+            "type": "Bike",
+            "name": "Litening Air",
+            "activities": 100,
+            "distance": 4_155_700,
+        }
+    ]
+
+    async def fake_request(*_args, **_kwargs):
+        call_count["n"] += 1
+        return sample_gear
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.gear.make_intervals_request", fake_request
+    )
+
+    # First call: cache cold, one API hit expected.
+    asyncio.run(get_gear_list(athlete_id="i1"))
+    assert call_count["n"] == 1
+
+    # Second call: cache warm, no additional API hit.
+    asyncio.run(get_gear_list(athlete_id="i1"))
+    assert call_count["n"] == 1
+
+    # refresh=True busts the cache and triggers a fresh fetch.
+    asyncio.run(get_gear_list(athlete_id="i1", refresh=True))
+    assert call_count["n"] == 2
+
+
+def test_get_activity_details_resolves_gear_name(monkeypatch):
+    """
+    Test get_activity_details injects the resolved gear name into the formatted output
+    when the activity payload contains a gear_id.
+    """
+    _reset_gear_cache()
+
+    activity = {
+        "name": "Morning Ride",
+        "id": 123,
+        "type": "Ride",
+        "startTime": "2024-01-01T08:00:00Z",
+        "distance": 1000,
+        "duration": 3600,
+        "gear_id": "b1",
+    }
+    gear_catalog = [{"id": "b1", "type": "Bike", "name": "Litening Air"}]
+
+    async def fake_request(url=None, **_kwargs):
+        # The activity endpoint and the gear endpoint share the same fake
+        # request; route by URL pattern.
+        if url and "/gear" in url:
+            return gear_catalog
+        return activity
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.activities.make_intervals_request", fake_request
+    )
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.gear.make_intervals_request", fake_request
+    )
+
+    result = asyncio.run(get_activity_details(123))
+    assert "Activity: Morning Ride" in result
+    assert "Gear:" in result
+    assert "Name: Litening Air" in result
+    assert "ID: b1" in result
+
+
+def test_get_activities_resolves_gear_name(monkeypatch):
+    """
+    Test get_activities injects resolved gear names for each activity in the list.
+    """
+    _reset_gear_cache()
+
+    activities = [
+        {
+            "name": "Ride 1",
+            "id": 1,
+            "type": "Ride",
+            "startTime": "2024-01-01T08:00:00Z",
+            "distance": 1000,
+            "duration": 3600,
+            "gear_id": "b1",
+        },
+        {
+            "name": "Ride 2",
+            "id": 2,
+            "type": "Ride",
+            "startTime": "2024-01-02T08:00:00Z",
+            "distance": 2000,
+            "duration": 5400,
+            "gear_id": "b2",
+        },
+    ]
+    gear_catalog = [
+        {"id": "b1", "type": "Bike", "name": "Litening Air"},
+        {"id": "b2", "type": "Bike", "name": "S-Works Tarmac SL8"},
+    ]
+
+    async def fake_request(url=None, **_kwargs):
+        if url and "/gear" in url:
+            return gear_catalog
+        return activities
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.activities.make_intervals_request", fake_request
+    )
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.gear.make_intervals_request", fake_request
+    )
+
+    result = asyncio.run(get_activities(athlete_id="1", limit=2, include_unnamed=True))
+    assert "Ride 1" in result
+    assert "Ride 2" in result
+    assert "Name: Litening Air" in result
+    assert "Name: S-Works Tarmac SL8" in result


### PR DESCRIPTION
… tool

The activity payload from Intervals.icu only includes the gear ID (e.g. b16177481), not the human-readable name. This left users seeing the ID but no name for which bike or pair of shoes was used.

Changes:
- New tools/gear.py with a module-level {gear_id: gear_name} cache per athlete, populated lazily from /athlete/{id}/gear on first activity lookup.
- New get_gear_list MCP tool that returns the full gear catalog for discovery, with refresh=True to bust the cache.
- get_activities and get_activity_details now resolve gear names in place (injected as _resolved_gear_name) before formatting.
- format_activity_summary prefers _resolved_gear_name, with the raw gear/gear_name/gear_id fields as fallbacks. Adds a Gear: section to the output.