### PR TITLE
feat: add ATP season planning and race event tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@ Model Context Protocol (MCP) server for connecting Claude and ChatGPT with the I
 
 If you find the Model Context Protocol (MCP) server useful, please consider supporting its continued development with a donation.
 
+## About this fork
+
+This fork adds a **season planning module** on top of the upstream server: five new MCP tools that let an AI assistant build and manage an Annual Training Plan (ATP) directly on your Intervals.icu calendar (automatic phase selection, weekly TSS targets, recovery weeks, and race event creation). See [`planning.py`](src/intervals_mcp_server/tools/planning.py) for details.
+
+These changes are proposed upstream in [mvilanova/intervals-mcp-server#112](https://github.com/mvilanova/intervals-mcp-server/pull/112), which is still awaiting review from the maintainer. Until it's merged (or if it never is), you can use this fork directly:
+
+```bash
+git clone https://github.com/Jochem-van-Appeldoorn/intervals-mcp-server.git
+cd intervals-mcp-server
+```
+
+Or grab a packaged version from the [Releases page](https://github.com/Jochem-van-Appeldoorn/intervals-mcp-server/releases) without needing git at all.
+
+Everything else below is unchanged from upstream and applies the same way to this fork.
+
 ## Requirements
 
 - Python 3.12 or higher
@@ -265,6 +280,11 @@ Once the server is running and Claude Desktop is configured, you can use the fol
 - `create_custom_item`: Create a new custom item for an athlete
 - `update_custom_item`: Update an existing custom item
 - `delete_custom_item`: Delete a custom item
+- `create_atp_plan`: Build a full Annual Training Plan up to an A-race date, posted to the calendar as phase notes *(this fork only)*
+- `get_atp_plan`: Read back the ATP phase notes for a date range *(this fork only)*
+- `get_atp_week_note`: Get the ATP phase note covering a specific week *(this fork only)*
+- `get_planning_context`: One-shot snapshot (CTL/ATL/TSB/HRV, ATP phase, planned workouts, upcoming races) for planning a given week *(this fork only)*
+- `add_race_event`: Create a race event (A/B/C priority) on the calendar *(this fork only)*
 
 ## Usage with ChatGPT
 

--- a/run-http.sh
+++ b/run-http.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+cd /home/jochem/intervals-mcp-server
+export MCP_TRANSPORT=http
+export API_KEY=28zrr3v30oon1bt5bejcw2a0y
+export ATHLETE_ID=i85629
+exec /home/jochem/.local/bin/uv run --directory /home/jochem/intervals-mcp-server --with-editable . python src/intervals_mcp_server/server.py

--- a/src/intervals_mcp_server/server.py
+++ b/src/intervals_mcp_server/server.py
@@ -85,7 +85,7 @@ from intervals_mcp_server.tools.events import (  # pylint: disable=wrong-import-
     get_event_by_id,
     get_events,
 )
-from intervals_mcp_server.tools.gear import get_gear_list  # pylint: disable=wrong-import-position  # noqa: E402
+from intervals_mcp_server.tools.gear import get_gear_list  # pylint: disable=wrong-import-position  # noqa: E402,F401
 from intervals_mcp_server.tools.wellness import get_wellness_data  # pylint: disable=wrong-import-position  # noqa: E402
 from intervals_mcp_server.tools.power_curves import get_athlete_power_curves  # pylint: disable=wrong-import-position  # noqa: E402
 from intervals_mcp_server.tools.custom_items import (  # pylint: disable=wrong-import-position  # noqa: E402

--- a/src/intervals_mcp_server/tools/__init__.py
+++ b/src/intervals_mcp_server/tools/__init__.py
@@ -33,6 +33,12 @@ from intervals_mcp_server.tools.power_curves import (  # noqa: F401
 )
 from intervals_mcp_server.tools.gear import get_gear_list  # noqa: F401
 from intervals_mcp_server.tools.wellness import get_wellness_data  # noqa: F401
+from intervals_mcp_server.tools.planning import (  # noqa: F401
+    create_atp_plan,
+    get_atp_plan,
+    get_atp_week_note,
+    get_planning_context,
+)
 
 
 def register_tools(mcp_instance: FastMCP) -> None:
@@ -70,4 +76,8 @@ __all__ = [
     "get_athlete_power_curves",
     "get_gear_list",
     "get_wellness_data",
+    "create_atp_plan",
+    "get_atp_plan",
+    "get_atp_week_note",
+    "get_planning_context",
 ]

--- a/src/intervals_mcp_server/tools/__init__.py
+++ b/src/intervals_mcp_server/tools/__init__.py
@@ -34,6 +34,7 @@ from intervals_mcp_server.tools.power_curves import (  # noqa: F401
 from intervals_mcp_server.tools.gear import get_gear_list  # noqa: F401
 from intervals_mcp_server.tools.wellness import get_wellness_data  # noqa: F401
 from intervals_mcp_server.tools.planning import (  # noqa: F401
+    add_race_event,
     create_atp_plan,
     get_atp_plan,
     get_atp_week_note,
@@ -76,6 +77,7 @@ __all__ = [
     "get_athlete_power_curves",
     "get_gear_list",
     "get_wellness_data",
+    "add_race_event",
     "create_atp_plan",
     "get_atp_plan",
     "get_atp_week_note",

--- a/src/intervals_mcp_server/tools/events.py
+++ b/src/intervals_mcp_server/tools/events.py
@@ -21,6 +21,21 @@ from intervals_mcp_server.mcp_instance import mcp  # noqa: F401
 config = get_config()
 
 
+def format_strength_description(title: str, blocks: list[dict]) -> str:
+    """Format strength training blocks as Intervals.icu bullet-point description.
+
+    Intervals.icu renders leading dashes as bullet points in workout descriptions,
+    matching the visual style of cycling workout steps.
+    """
+    lines = [title, ""]
+    for block in blocks:
+        lines.append(block["name"])
+        for exercise in block["exercises"]:
+            lines.append(f"- {exercise}")
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
 def _prepare_event_data(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     name: str,
     workout_type: str,
@@ -28,17 +43,23 @@ def _prepare_event_data(  # pylint: disable=too-many-arguments,too-many-position
     workout_doc: WorkoutDoc | None,
     moving_time: int | None,
     distance: int | None,
+    description_override: str | None = None,
 ) -> dict[str, Any]:
     """Prepare event data dictionary for API request.
 
     Many arguments are required to match the Intervals.icu API event structure.
     """
     resolved_workout_type = resolve_activity_type(name, workout_type)
+    description = (
+        description_override
+        if description_override is not None
+        else (str(workout_doc) if workout_doc else None)
+    )
     return {
         "start_date_local": start_date + "T00:00:00",
         "category": "WORKOUT",
         "name": name,
-        "description": str(workout_doc) if workout_doc else None,
+        "description": description,
         "type": resolved_workout_type,
         "moving_time": moving_time,
         "distance": distance,
@@ -271,6 +292,7 @@ async def add_or_update_event(  # pylint: disable=too-many-arguments,too-many-po
     workout_doc: WorkoutDoc | None = None,
     moving_time: int | None = None,
     distance: int | None = None,
+    strength_training: list[dict] | None = None,
 ) -> str:
     """Post event for an athlete to Intervals.icu this follows the event api from intervals.icu
     If event_id is provided, the event will be updated instead of created.
@@ -284,9 +306,13 @@ async def add_or_update_event(  # pylint: disable=too-many-arguments,too-many-po
         start_date: Start date in YYYY-MM-DD format (optional, defaults to today)
         name: Name of the activity
         workout_doc: steps as a list of Step objects (optional, but necessary to define workout steps)
-        workout_type: Workout type (e.g. Ride, Run, Swim, Walk, Row)
+        workout_type: Workout type (e.g. Ride, Run, Swim, Walk, Row, WeightTraining)
         moving_time: Total expected moving time of the workout in seconds (optional)
         distance: Total expected distance of the workout in meters (optional)
+        strength_training: List of exercise blocks for WeightTraining events (optional).
+                           Each block has "name" (str) and "exercises" (list[str]).
+                           When provided with workout_type="WeightTraining", the description
+                           is auto-formatted with Intervals.icu bullet-point syntax.
 
     Example:
         "workout_doc": {
@@ -346,8 +372,12 @@ async def add_or_update_event(  # pylint: disable=too-many-arguments,too-many-po
 
     try:
         validated_date = validate_date(start_date)
+        strength_desc: str | None = None
+        if workout_type == "WeightTraining" and strength_training:
+            strength_desc = format_strength_description(name, strength_training)
         event_data = _prepare_event_data(
-            name, workout_type, validated_date, workout_doc, moving_time, distance
+            name, workout_type, validated_date, workout_doc, moving_time, distance,
+            description_override=strength_desc,
         )
         return await _create_or_update_event_request(
             athlete_id_to_use, api_key, event_data, validated_date, event_id

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -130,7 +130,9 @@ def _reason_for_phases(current_ctl: float, goal_ctl: float, total_weeks: int) ->
     ratio = current_ctl / max(goal_ctl, 1.0)
     gap = round(goal_ctl - current_ctl)
     if total_weeks <= 5:
-        return f"Only {total_weeks} weeks available — going straight to peak phase."
+        phases = _determine_phases(total_weeks, current_ctl, goal_ctl)
+        phase_seq = " → ".join(_PHASES[name]["label"] for name, _ in phases)
+        return f"Only {total_weeks} weeks available — {phase_seq}."
     if ratio >= 0.90:
         return (
             f"CTL {round(current_ctl)} is close to goal CTL {goal_ctl} "
@@ -160,11 +162,10 @@ def _weeks_in(start: date, end: date) -> int:
 
 
 
-def _week_tss(phase: str, goal_tss: int, week: int, total_weeks: int, cycle: int) -> str:
+def _week_tss(phase: str, goal_tss: int, week: int, cycle: int, load_weeks: list[int]) -> str:
     factor = _PHASES[phase]["tss_factor"]
     if week % cycle == 0:
         return f"~{round(goal_tss * factor * 0.60 / 50) * 50} TSS  ← recovery week"
-    load_weeks = [w for w in range(1, total_weeks + 1) if w % cycle != 0]
     idx = load_weeks.index(week) if week in load_weeks else 0
     prog = 0.85 + 0.15 * (idx / max(len(load_weeks) - 1, 1))
     tss = round(goal_tss * factor * prog / 50) * 50
@@ -185,6 +186,7 @@ def _build_phase_note(
 ) -> str:
     p = _PHASES[phase]
     total_wks = _weeks_in(start, end)
+    load_weeks = [w for w in range(1, total_wks + 1) if w % cycle != 0]
 
     lines = [
         f"Phase {phase_num}/{total_phases}: {p['label']}",
@@ -200,7 +202,7 @@ def _build_phase_note(
     for w in range(1, total_wks + 1):
         w_start = start + timedelta(weeks=w - 1)
         w_end = min(w_start + timedelta(days=6), end)
-        lines.append(f"  Week {w} ({w_start} – {w_end}): {_week_tss(phase, goal_tss, w, total_wks, cycle)}")
+        lines.append(f"  Week {w} ({w_start} – {w_end}): {_week_tss(phase, goal_tss, w, cycle, load_weeks)}")
 
     lines += ["", f"A-race: {race_name} ({race_date})"]
     if phase_races:
@@ -362,7 +364,7 @@ async def create_atp_plan(
             "name": f"ATP — {_PHASES[ph['name']]['label']}",
             "description": description,
             "start_date_local": ph["start"].isoformat() + "T00:00:00",
-            "end_date_local": ph["end"].isoformat() + "T00:00:00",
+            "end_date_local": (ph["end"] + timedelta(days=1)).isoformat() + "T00:00:00",
             "color": _PHASES[ph["name"]]["color"],
         }
 
@@ -443,7 +445,7 @@ async def get_atp_plan(
     events = result if isinstance(result, list) else []
     notes = [
         e for e in events
-        if e.get("category") == "NOTE" and (e.get("name") or "").startswith("ATP")
+        if isinstance(e, dict) and e.get("category") == "NOTE" and (e.get("name") or "").startswith("ATP")
     ]
 
     if not notes:
@@ -506,7 +508,7 @@ async def get_atp_week_note(
     events = result if isinstance(result, list) else []
     notes = [
         e for e in events
-        if e.get("category") == "NOTE" and (e.get("name") or "").startswith("ATP")
+        if isinstance(e, dict) and e.get("category") == "NOTE" and (e.get("name") or "").startswith("ATP")
     ]
 
     if not notes:
@@ -740,7 +742,7 @@ async def add_race_event(
     if duration_minutes is not None:
         event_data["moving_time"] = duration_minutes * 60
     if distance_km is not None:
-        event_data["distance"] = int(distance_km * 1000)
+        event_data["distance"] = round(distance_km * 1000)
     if expected_tss is not None:
         event_data["icu_training_load"] = expected_tss
 

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -645,7 +645,7 @@ async def get_planning_context(
     # Upcoming races
     sections.append("\n## Komende wedstrijden (120 dagen)")
     if isinstance(races_result, list) and races_result:
-        races = [e for e in races_result if e.get("category") in ("RACE", "A", "B", "C")]
+        races = [e for e in races_result if e.get("category") in ("RACE_A", "RACE_B", "RACE_C")]
         if races:
             for r in races:
                 d = (r.get("start_date_local") or "")[:10]
@@ -658,3 +658,78 @@ async def get_planning_context(
         sections.append("Geen wedstrijden gepland.")
 
     return "\n".join(sections)
+
+
+@mcp.tool()
+async def add_race_event(
+    name: str,
+    race_date: str,
+    priority: str = "A",
+    start_time: str = "10:00:00",
+    sport: str = "Ride",
+    duration_minutes: int | None = None,
+    distance_km: float | None = None,
+    expected_tss: int | None = None,
+    athlete_id: str | None = None,
+    api_key: str | None = None,
+) -> str:
+    """Add a race event to the Intervals.icu calendar.
+
+    Creates an event with category RACE_A, RACE_B, or RACE_C. The priority
+    determines how the ATP and HRV coach treat the event:
+    - A: most important race — full taper, no heavy training the week before
+    - B: important race — reduce load 2 days before
+    - C: training race — treat as a hard training day
+
+    Args:
+        name: Name of the race (e.g. "Ronde van Vlaanderen")
+        race_date: Date of the race in YYYY-MM-DD format
+        priority: Race priority — A, B, or C (default A)
+        start_time: Start time in HH:MM:SS format (default 10:00:00)
+        sport: Sport type — Ride, Run, Swim, etc. (default Ride)
+        duration_minutes: Expected race duration in minutes (optional)
+        distance_km: Expected race distance in km (optional)
+        expected_tss: Expected Training Stress Score for the race (optional)
+        athlete_id: The Intervals.icu athlete ID (optional)
+        api_key: The Intervals.icu API key (optional)
+    """
+    athlete_id_to_use, error_msg = resolve_athlete_id(athlete_id, config.athlete_id)
+    if error_msg:
+        return error_msg
+
+    try:
+        validate_date(race_date)
+    except ValueError as e:
+        return f"Error in race_date: {e}"
+
+    priority_upper = priority.strip().upper()
+    if priority_upper not in ("A", "B", "C"):
+        return "Error: priority must be A, B, or C."
+
+    event_data: dict[str, Any] = {
+        "category": f"RACE_{priority_upper}",
+        "type": sport,
+        "name": name,
+        "start_date_local": f"{race_date}T{start_time}",
+    }
+
+    if duration_minutes is not None:
+        event_data["moving_time"] = duration_minutes * 60
+    if distance_km is not None:
+        event_data["distance"] = int(distance_km * 1000)
+    if expected_tss is not None:
+        event_data["icu_training_load"] = expected_tss
+
+    result = await make_intervals_request(
+        url=f"/athlete/{athlete_id_to_use}/events",
+        api_key=api_key,
+        data=event_data,
+        method="POST",
+    )
+
+    if isinstance(result, dict) and "error" in result:
+        return f"Error adding race: {result.get('message')}"
+
+    event_id = result.get("id") if isinstance(result, dict) else None
+    id_str = f" (id: {event_id})" if event_id else ""
+    return f"Race '{name}' aangemaakt op {race_date} [RACE_{priority_upper}]{id_str}."

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -734,6 +734,12 @@ async def add_race_event(
     if isinstance(result, dict) and "error" in result:
         return f"Error adding race: {result.get('message')}"
 
-    event_id = result.get("id") if isinstance(result, dict) else None
+    if not isinstance(result, dict):
+        return f"Unexpected response adding race: {result}"
+
+    event_id = result.get("id")
+    saved_category = result.get("category", "not returned")
     id_str = f" (id: {event_id})" if event_id else ""
-    return f"Race '{name}' added on {race_date} [RACE_{priority_upper}]{id_str}."
+    category_ok = saved_category == f"RACE_{priority_upper}"
+    category_note = "" if category_ok else f" — WARNING: API saved category as '{saved_category}', expected 'RACE_{priority_upper}'"
+    return f"Race '{name}' added on {race_date} [RACE_{priority_upper}]{id_str}.{category_note}"

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -607,7 +607,8 @@ async def create_atp_plan(
     if race_dt < today:
         return f"Error: race_date {race_date} is in the past. Provide a future date."
 
-    today_monday = _monday_of(today)
+    days_ahead = (7 - today.weekday()) % 7 or 7  # next Monday, never today
+    today_monday = today + timedelta(days=days_ahead)
     race_monday = _monday_of(race_dt)
     total_weeks = max(1, (race_monday - today_monday).days // 7 + 1)
 

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -84,6 +84,10 @@ _TRAILING_PRIORITY_RE = re.compile(r'^(.*?)\s*\[([A-Ca-c])\]\s*$')
 _BASIS_20MIN_THRESHOLD: float = 0.85  # 20-min power must be >= ftp * this
 _BASIS_60MIN_THRESHOLD: float = 0.75  # 60-min power must be >= ftp * this
 
+# CTL-ratio thresholds used inside the basis_present=True branch.
+_BASE_SKIP_RATIO: float = 0.70   # at or above: skip Base entirely → straight to Build
+_BASE_SHORT_RATIO: float = 0.50  # at or above (but below SKIP): 2-week Base, then Build
+
 
 def _is_atp_note(e: object) -> bool:
     return (
@@ -300,12 +304,19 @@ def _determine_phases(
 
     # ---- Basis-aware branch ----------------------------------------
     if basis_present is True:
-        if ratio >= 0.70:
-            # Basis confirmed + CTL close enough → skip base, go straight to build
+        if ratio >= _BASE_SKIP_RATIO:
+            # Strong basis + small CTL gap → skip Base entirely
             return [("build", remaining)] + tail
+        elif ratio >= _BASE_SHORT_RATIO:
+            # Strong basis but moderate CTL gap → fixed 2-week Base for volume ramp
+            base_wks = 2
+            build_wks = remaining - base_wks
+            if build_wks < 3:
+                return [("build", remaining)] + tail
+            return [("base", base_wks), ("build", build_wks)] + tail
         else:
-            # Big CTL gap but basis is there → short base to ramp volume, then build
-            base_wks = max(2, remaining // 4)
+            # Strong basis but very large CTL gap → full Base (Preparation not needed)
+            base_wks = max(3, remaining // 3)
             build_wks = remaining - base_wks
             if build_wks < 3:
                 return [("build", remaining)] + tail
@@ -356,6 +367,17 @@ def _determine_phases(
     return phases + tail
 
 
+def _basis_decision_note(basis_present: bool | None, ratio: float) -> str | None:
+    """Return a short descriptive prefix for the Decision line, or None for the default."""
+    if basis_present is not True:
+        return None
+    if ratio >= _BASE_SKIP_RATIO:
+        return "skipping Base entirely"
+    if ratio >= _BASE_SHORT_RATIO:
+        return "basis present, CTL gap large → short Base (2 wk)"
+    return "basis present, CTL gap very large → full Base, no Preparation"
+
+
 def _phase_selection_summary(
     current_ctl: float,
     goal_ctl: float,
@@ -372,10 +394,11 @@ def _phase_selection_summary(
     goal_ctl_int = round(goal_ctl)
     current_ctl_int = round(current_ctl)
     gap = goal_ctl_int - current_ctl_int
+    ratio = current_ctl / max(goal_ctl, 1.0)
     phase_seq = " → ".join(_PHASES[name]["label"] for name, _ in phase_list)
 
     lines = [
-        f"  Current CTL: {current_ctl_int} (goal: {goal_ctl_int}, gap: {gap} pts)",
+        f"  Current CTL: {current_ctl_int} (goal: {goal_ctl_int}, gap: {gap} pts, ratio: {round(ratio * 100)}%)",
     ]
 
     # Power curve line
@@ -397,9 +420,7 @@ def _phase_selection_summary(
 
     # Basis assessment line
     if basis_present is True:
-        lines.append(
-            f"  Basis assessment: PRESENT — strong 20min and 60min values in last 30 days"
-        )
+        lines.append("  Basis assessment: PRESENT — strong 20min and 60min values in last 30 days")
     elif basis_present is False:
         if power_20min is None and power_60min is None:
             lines.append("  Basis assessment: ABSENT — no recent riding detected")
@@ -411,7 +432,9 @@ def _phase_selection_summary(
     else:
         lines.append("  Basis assessment: N/A — no power curve data, using CTL-gap only")
 
-    lines.append(f"  Decision: {phase_seq}")
+    note = _basis_decision_note(basis_present, ratio)
+    decision = f"{note} → {phase_seq}" if note else phase_seq
+    lines.append(f"  Decision: {decision}")
     return "\n".join(lines)
 
 

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -89,6 +89,116 @@ def _is_atp_note(e: object) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Power zone, strength, and multi-sport helpers
+# ---------------------------------------------------------------------------
+
+def _ftp_power_ranges(ftp: int) -> dict[str, str]:
+    return {
+        "sweet spot": f"{round(ftp * 0.88)}–{round(ftp * 0.93)} W",
+        "threshold": f"{round(ftp * 0.95)}–{round(ftp * 1.05)} W",
+        "vo2max": f"{round(ftp * 1.06)}–{round(ftp * 1.20)} W",
+    }
+
+
+def _annotate_sessions_with_power(sessions: list[str], ftp: int) -> list[str]:
+    ranges = _ftp_power_ranges(ftp)
+    result = []
+    for s in sessions:
+        s_lower = s.lower()
+        for keyword, watt_range in ranges.items():
+            if keyword in s_lower and " W" not in s:
+                s = re.sub(r"\s+per week$", "", s, flags=re.IGNORECASE).strip()
+                s = f"{s} ({watt_range})"
+                break
+        result.append(s)
+    return result
+
+
+def _build_strength_section(phase: str, strength: dict[str, Any]) -> list[str]:
+    if phase == "race":
+        return []
+
+    sessions_per_week: int = strength.get("sessions_per_week", 0)
+    duration: int = strength.get("session_duration_minutes", 0)
+    equipment: list[str] = strength.get("equipment", [])
+    all_blocks: list[dict[str, Any]] = strength.get("blocks", [])
+
+    if phase == "peak":
+        active_sessions = strength.get("peak_phase_sessions", sessions_per_week)
+        peak_block_names: list[str] = strength.get("peak_phase_blocks", [])
+        active_blocks = (
+            [b for b in all_blocks if any(b.get("name", "").startswith(n) for n in peak_block_names)]
+            if peak_block_names else all_blocks
+        )
+        header = f"Strength ({active_sessions}x/week, ~{duration} min — peak phase, reduced):"
+        show_recovery_note = False
+    else:
+        active_sessions = sessions_per_week
+        active_blocks = all_blocks
+        eq_str = f", equipment: {', '.join(equipment)}" if equipment else ""
+        header = f"Strength ({active_sessions}x/week, ~{duration} min{eq_str}):"
+        show_recovery_note = "recovery_week_sessions" in strength
+
+    lines = [header]
+    for block in active_blocks:
+        name = block.get("name", "")
+        spw = block.get("sessions_per_week", "")
+        exercises: list[str] = block.get("exercises", [])
+        freq_str = f" ({spw}x/week)" if spw else ""
+        lines.append(f"  {name}{freq_str}:")
+        lines.append(f"    {', '.join(exercises)}")
+
+    if show_recovery_note:
+        rec_sessions: int = strength["recovery_week_sessions"]
+        rec_blocks: list[str] = strength.get("recovery_week_blocks", [])
+        block_str = ", ".join(rec_blocks) if rec_blocks else "all blocks"
+        lines.append(f"  Recovery week: {block_str} only, {rec_sessions}x")
+
+    return lines
+
+
+_GENERIC_STRENGTH_PHASE: dict[str, str] = {
+    "preparation": "2–3× per week. Core, functional strength. Keep sessions short (20–30 min).",
+    "base": "2–3× per week. Core, functional strength. Keep sessions short (20–30 min).",
+    "build": "2× per week. Maintenance. Core and stability only.",
+    "peak": "2× per week, core/stability only. Skip heavy lifts.",
+    "race": "No strength training — rest and race.",
+}
+
+_SPORT_PHASE_GUIDANCE: dict[str, dict[str, str]] = {
+    "running": {
+        "preparation": "2× per week, easy Z2 runs (30–45 min). Focus on running form and consistency.",
+        "base": "2–3× per week, Z2 easy runs (45–60 min). Build aerobic base.",
+        "build": "2–3× per week, include 1× tempo or interval run.",
+        "peak": "2× per week, 1× race-pace strides + 1× easy run. Keep it fresh.",
+        "race": "Easy jog (20–30 min) or rest. Save legs for racing.",
+    },
+    "swimming": {
+        "preparation": "2× per week, technique drills (1,500–2,000 m). Stroke efficiency focus.",
+        "base": "2–3× per week, aerobic sets (2,000–3,000 m). Technique + endurance.",
+        "build": "2–3× per week, include CSS-pace threshold intervals (2,500–3,500 m).",
+        "peak": "2× per week, short race-pace sets. Maintain feel for water.",
+        "race": "1× activation swim (800–1,000 m easy). Race day: warm-up as planned.",
+    },
+}
+
+
+def _build_extra_sports_sections(phase: str, sports: list[str]) -> list[str]:
+    lines: list[str] = []
+    for sport in sports:
+        if sport == "cycling":
+            continue
+        if sport == "strength":
+            guidance = _GENERIC_STRENGTH_PHASE.get(phase, "Follow strength plan.")
+            lines += ["\nStrength this phase:", f"  {guidance}"]
+            continue
+        guidance = _SPORT_PHASE_GUIDANCE.get(sport, {}).get(phase)
+        lines.append(f"\n{sport.capitalize()} this phase:")
+        lines.append(f"  {guidance}" if guidance else "  Follow sport-specific plan; scale to available hours.")
+    return lines
+
+
+# ---------------------------------------------------------------------------
 # Phase auto-selection logic (relative to goal CTL, not absolute thresholds)
 # ---------------------------------------------------------------------------
 
@@ -217,10 +327,21 @@ def _build_phase_note(
     race_name: str,
     race_date: date,
     phase_races: list[dict],
+    ftp: int | None = None,
+    strength_training: dict[str, Any] | None = None,
+    sports: list[str] | None = None,
+    fixed_weekly_events: list[str] | None = None,
 ) -> str:
     p = _PHASES[phase]
     total_wks = _weeks_in(start, end)
     load_week_idx = {w: i for i, w in enumerate(w for w in range(1, total_wks + 1) if w % cycle != 0)}
+
+    multi_sport = sports is not None and len([s for s in sports if s != "strength"]) > 1
+    sessions_label = "Key cycling sessions per week:" if multi_sport else "Key sessions per week:"
+
+    key_sessions = p["key_sessions"]
+    if ftp is not None:
+        key_sessions = _annotate_sessions_with_power(key_sessions, ftp)
 
     lines = [
         f"Phase {phase_num}/{total_phases}: {p['label']}",
@@ -228,8 +349,8 @@ def _build_phase_note(
         f"Goal: {p['focus']}",
         f"Intensity: {p['intensity']}",
         "",
-        "Key sessions per week:",
-        *[f"  • {s}" for s in p["key_sessions"]],
+        sessions_label,
+        *[f"  • {s}" for s in key_sessions],
         "",
         "Weekly schedule:",
     ]
@@ -237,6 +358,22 @@ def _build_phase_note(
         w_start = start + timedelta(weeks=w - 1)
         w_end = min(w_start + timedelta(days=6), end)
         lines.append(f"  Week {w} ({w_start} – {w_end}): {_week_tss(phase, goal_tss, w, cycle, load_week_idx)}")
+
+    if sports:
+        extra_sports = [s for s in sports if s != "strength" or strength_training is None]
+        lines.extend(_build_extra_sports_sections(phase, extra_sports))
+
+    if strength_training:
+        strength_lines = _build_strength_section(phase, strength_training)
+        if strength_lines:
+            lines.append("")
+            lines.extend(strength_lines)
+
+    if fixed_weekly_events:
+        lines.append("")
+        lines.append("Fixed weekly events (do not modify):")
+        for ev in fixed_weekly_events:
+            lines.append(f"  • {ev}")
 
     lines += ["", f"A-race: {race_name} ({race_date})"]
     if phase_races:
@@ -261,6 +398,11 @@ async def create_atp_plan(
     additional_races: str | None = None,
     athlete_id: str | None = None,
     api_key: str | None = None,
+    ftp: int | None = None,
+    weekly_hours: float | None = None,
+    sports: list[str] | None = None,
+    strength_training: dict[str, Any] | None = None,
+    fixed_weekly_events: list[str] | None = None,
 ) -> str:
     """Create an ATP (Annual Training Plan) in Intervals.icu for a goal race.
 
@@ -295,6 +437,24 @@ async def create_atp_plan(
                           e.g. "2026-03-21 Dwars door Vlaanderen [C]"
         athlete_id: The Intervals.icu athlete ID (optional)
         api_key: The Intervals.icu API key (optional)
+        ftp: FTP in watts (optional). When provided, power targets in phase notes
+             are made concrete: sweet spot ftp×0.88–0.93, threshold ftp×0.95–1.05,
+             VO2max ftp×1.06–1.20.
+        weekly_hours: Available training hours per week (optional). Used to
+                      validate TSS targets; if the goal exceeds ~65 TSS/h the
+                      peak-week target is capped to what is achievable.
+        sports: Sports trained alongside cycling (optional). Supported:
+                "cycling", "running", "swimming", "strength". Cycling stays
+                primary. With 3+ non-strength sports, cycling TSS is reduced
+                by 10% to keep total load manageable.
+        strength_training: Detailed weekly strength routine (optional). Object
+                           with blocks, exercises, equipment. Automatically
+                           scaled for recovery weeks and the peak phase.
+                           No strength in the race phase.
+        fixed_weekly_events: Recurring events that must not be overridden
+                             (optional). Listed in each phase note so the
+                             weekly planner can account for them.
+                             e.g. ["Tuesday evening criterium (Papendal)"]
     """
     athlete_id_to_use, error_msg = resolve_athlete_id(athlete_id, config.athlete_id)
     if error_msg:
@@ -311,6 +471,19 @@ async def create_atp_plan(
 
     if recovery_cycle not in (3, 4):
         return "Error: recovery_cycle must be 3 or 4."
+
+    if ftp is not None and ftp < 50:
+        return "Error: ftp must be at least 50 W."
+
+    if weekly_hours is not None and weekly_hours <= 0:
+        return "Error: weekly_hours must be a positive number."
+
+    _valid_sports = {"cycling", "running", "swimming", "strength"}
+    if sports is not None:
+        invalid = [s for s in sports if s.lower() not in _valid_sports]
+        if invalid:
+            return f"Error: unsupported sports: {invalid}. Supported: cycling, running, swimming, strength."
+        sports = [s.lower() for s in sports]
 
     today = date.today()
     if race_dt < today:
@@ -341,6 +514,24 @@ async def create_atp_plan(
 
     # Weekly TSS in peak build weeks ≈ goal_ctl × 7
     goal_weekly_tss = max(50, round(goal_ctl * 7 / 50) * 50)
+
+    # Multi-sport: reduce cycling TSS by 10% when 3+ non-strength sports
+    tss_sport_note = ""
+    if sports is not None:
+        active_sport_count = len([s for s in sports if s != "strength"])
+        if active_sport_count >= 3:
+            original_tss = goal_weekly_tss
+            goal_weekly_tss = max(50, round(goal_weekly_tss * 0.90 / 50) * 50)
+            tss_sport_note = f" (reduced from {original_tss} for multi-sport load)"
+
+    # Weekly hours: cap TSS if goal exceeds what is achievable (~65 TSS/h)
+    tss_hours_note = ""
+    if weekly_hours is not None:
+        max_feasible_tss = max(50, round(weekly_hours * 65 / 50) * 50)
+        if goal_weekly_tss > max_feasible_tss:
+            original_tss = goal_weekly_tss
+            goal_weekly_tss = max_feasible_tss
+            tss_hours_note = f" (capped from {original_tss} to fit {weekly_hours}h/week)"
 
     # Parse additional races
     extra_races: list[dict] = []
@@ -417,6 +608,10 @@ async def create_atp_plan(
             race_name=race_name,
             race_date=race_dt,
             phase_races=phase_races,
+            ftp=ftp,
+            strength_training=strength_training,
+            sports=sports,
+            fixed_weekly_events=fixed_weekly_events,
         )
         event_data: dict[str, Any] = {
             "category": "NOTE",
@@ -474,13 +669,20 @@ async def create_atp_plan(
         f"ATP created for {race_name} ({race_date})",
         f"Period: {today_monday} – {race_monday + timedelta(days=6)} ({total_weeks} weeks)",
         f"Current CTL: {ctl_source}",
-        f"Goal CTL: {goal_ctl}  →  Peak week TSS target: ~{goal_weekly_tss}",
+        f"Goal CTL: {goal_ctl}  →  Peak week TSS target: ~{goal_weekly_tss}{tss_sport_note}{tss_hours_note}",
         f"Phase selection: {reason}",
         f"Phases: {phase_names}",
         f"Recovery cycle: every {recovery_cycle} weeks",
-        "",
-        "Posted to calendar:",
-    ] + posted_lines
+    ]
+    if sports:
+        summary.append(f"Sports: {', '.join(sports)}")
+    if ftp is not None:
+        summary.append(f"FTP: {ftp} W")
+    if weekly_hours is not None:
+        summary.append(f"Weekly hours: {weekly_hours} h")
+    if fixed_weekly_events:
+        summary.append(f"Fixed events: {'; '.join(fixed_weekly_events)}")
+    summary += ["", "Posted to calendar:"] + posted_lines
 
     return "\n".join(summary)
 

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -1,0 +1,655 @@
+"""
+Planning-related MCP tools for Intervals.icu.
+
+ATP (Annual Training Plan) tools that adapt to the available time and the
+athlete's current fitness level:
+- create_atp_plan  fetches current CTL and auto-determines which phases are
+                   needed, how long they should be, and posts them as NOTE
+                   events on the Intervals.icu calendar.
+- get_atp_plan     reads all phase notes from the calendar.
+- get_atp_week_note  returns the phase note covering a specific week.
+- get_planning_context  returns fitness + ATP note + events for weekly planning.
+"""
+
+import asyncio
+from datetime import date, timedelta
+from typing import Any
+
+from intervals_mcp_server.api.client import make_intervals_request
+from intervals_mcp_server.config import get_config
+from intervals_mcp_server.mcp_instance import mcp  # noqa: F401
+from intervals_mcp_server.utils.validation import resolve_athlete_id, validate_date
+
+config = get_config()
+
+# ---------------------------------------------------------------------------
+# Phase definitions
+# ---------------------------------------------------------------------------
+
+_PHASES: dict[str, dict[str, Any]] = {
+    "preparation": {
+        "label": "Voorbereiding",
+        "color": "green",
+        "focus": "Algemene conditie opbouwen. Aerobe basis leggen, kracht en techniek.",
+        "intensity": "80% Z2, 15% sweetspot, 5% drempel.",
+        "key_sessions": ["Lange Z2 duurritten", "Krachttraining", "Soepelheid / techniek"],
+        "tss_factor": 0.60,
+    },
+    "base": {
+        "label": "Basis",
+        "color": "blue",
+        "focus": "Aerobe motor versterken. Hoog volume Z2, sweetspot, drempel introductie.",
+        "intensity": "65% Z2, 25% sweetspot, 10% drempel.",
+        "key_sessions": ["Lange duurritten (3–5 uur)", "2× sweetspot per week", "1× drempelinterval"],
+        "tss_factor": 0.80,
+    },
+    "build": {
+        "label": "Opbouw",
+        "color": "orange",
+        "focus": "Wedstrijdspecifieke kwaliteiten. Drempel, VO2max en anaerobe capaciteit uitbouwen.",
+        "intensity": "40% Z2, 30% drempel, 30% VO2max / anaeroob.",
+        "key_sessions": ["2× VO2max of drempel per week", "Lange duurrit", "Wedstrijdsimulatie"],
+        "tss_factor": 1.00,
+    },
+    "peak": {
+        "label": "Piek",
+        "color": "red",
+        "focus": "Scherp worden voor de koers. Volume daalt, intensiteit blijft hoog. Tapering.",
+        "intensity": "50% Z2, 25% drempel, 25% VO2max — kortere intervallen.",
+        "key_sessions": ["Race-pace intervallen", "Activatierit 2 dagen voor koers", "Rustdag voor koers"],
+        "tss_factor": 0.65,
+    },
+    "race": {
+        "label": "Koers",
+        "color": "red",
+        "focus": "Presteren op de A-koers. Minimale training, volle focus op wedstrijd en herstel.",
+        "intensity": "Wedstrijd + herstelritten.",
+        "key_sessions": ["Activatierit daags voor koers", "Wedstrijd", "Actief herstel erna"],
+        "tss_factor": 0.50,
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Phase auto-selection logic (relative to goal CTL, not absolute thresholds)
+# ---------------------------------------------------------------------------
+
+
+def _determine_phases(total_weeks: int, current_ctl: float, goal_ctl: float) -> list[tuple[str, int]]:
+    """Return ordered (phase_name, weeks) based on available weeks and CTL gap.
+
+    Uses the ratio current_ctl / goal_ctl so thresholds scale with the event:
+    - UCI belofte targeting CTL 110 with current 70 → big gap → needs base
+    - Toertocht finisher targeting CTL 60 with current 50 → small gap → straight to build
+    """
+    peak_wks = min(2, max(1, total_weeks // 7))
+    race_wks = 1
+    remaining = total_weeks - peak_wks - race_wks
+
+    tail = [("peak", peak_wks), ("race", race_wks)]
+
+    if remaining <= 0:
+        return tail
+
+    ratio = current_ctl / max(goal_ctl, 1.0)
+
+    if remaining <= 4 or ratio >= 0.90:
+        # Almost at goal CTL or very little time → straight to build
+        return [("build", remaining)] + tail
+
+    if ratio >= 0.70:
+        # Moderate gap (70–90% of goal) → short base block + build
+        base_wks = max(3, remaining // 3)
+        build_wks = remaining - base_wks
+        if build_wks < 3:
+            return [("build", remaining)] + tail
+        return [("base", base_wks), ("build", build_wks)] + tail
+
+    # Large gap (< 70% of goal) → prep + base + build
+    prep_wks = max(2, remaining // 5)
+    base_wks = max(3, (remaining - prep_wks) * 2 // 3)
+    build_wks = remaining - prep_wks - base_wks
+
+    if build_wks < 3:
+        prep_wks = 0
+        base_wks = max(3, remaining // 2)
+        build_wks = remaining - base_wks
+        if build_wks < 1:
+            # remaining too small for both base and build — collapse to pure build
+            return [("build", remaining)] + tail
+
+    phases: list[tuple[str, int]] = []
+    if prep_wks >= 2:
+        phases.append(("preparation", prep_wks))
+    phases.append(("base", base_wks))
+    phases.append(("build", build_wks))
+    return phases + tail
+
+
+def _reason_for_phases(current_ctl: float, goal_ctl: float, total_weeks: int) -> str:
+    ratio = current_ctl / max(goal_ctl, 1.0)
+    gap = round(goal_ctl - current_ctl)
+    if total_weeks <= 5:
+        return f"Slechts {total_weeks} weken beschikbaar — direct naar piek-fase."
+    if ratio >= 0.90:
+        return (
+            f"CTL {round(current_ctl)} is al dicht bij doel-CTL {goal_ctl} "
+            f"(gap: {gap}) — direct naar opbouwfase."
+        )
+    if ratio >= 0.70:
+        return (
+            f"CTL {round(current_ctl)} is {gap} punten onder doel-CTL {goal_ctl} "
+            f"({round(ratio * 100)}%) — korte basisblok gevolgd door opbouwfase."
+        )
+    return (
+        f"CTL {round(current_ctl)} is {gap} punten onder doel-CTL {goal_ctl} "
+        f"({round(ratio * 100)}%) — voorbereiding en basisblok nodig voor opbouw."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Note content builders
+# ---------------------------------------------------------------------------
+
+def _monday_of(d: date) -> date:
+    return d - timedelta(days=d.weekday())
+
+
+def _weeks_in(start: date, end: date) -> int:
+    return max(1, ((end - start).days + 1 + 6) // 7)
+
+
+def _recovery_week_numbers(total_weeks: int, cycle: int) -> list[int]:
+    return [w for w in range(1, total_weeks + 1) if w % cycle == 0]
+
+
+def _week_tss(phase: str, goal_tss: int, week: int, total_weeks: int, cycle: int) -> str:
+    factor = _PHASES[phase]["tss_factor"]
+    if week % cycle == 0:
+        return f"~{round(goal_tss * factor * 0.60 / 50) * 50} TSS  ← herstelweek"
+    load_weeks = [w for w in range(1, total_weeks + 1) if w % cycle != 0]
+    idx = load_weeks.index(week) if week in load_weeks else 0
+    prog = 0.85 + 0.15 * (idx / max(len(load_weeks) - 1, 1))
+    tss = round(goal_tss * factor * prog / 50) * 50
+    return f"~{tss} TSS"
+
+
+def _build_phase_note(
+    phase: str,
+    phase_num: int,
+    total_phases: int,
+    start: date,
+    end: date,
+    cycle: int,
+    goal_tss: int,
+    race_name: str,
+    race_date: date,
+    phase_races: list[dict],
+) -> str:
+    p = _PHASES[phase]
+    total_wks = _weeks_in(start, end)
+
+    lines = [
+        f"Fase {phase_num}/{total_phases}: {p['label']}",
+        f"Periode: {start} – {end} ({total_wks} weken)",
+        f"Doel: {p['focus']}",
+        f"Intensiteit: {p['intensity']}",
+        "",
+        "Hoofdtrainingen per week:",
+        *[f"  • {s}" for s in p["key_sessions"]],
+        "",
+        "Weekschema:",
+    ]
+    for w in range(1, total_wks + 1):
+        w_start = start + timedelta(weeks=w - 1)
+        w_end = min(w_start + timedelta(days=6), end)
+        lines.append(f"  Week {w} ({w_start} – {w_end}): {_week_tss(phase, goal_tss, w, total_wks, cycle)}")
+
+    lines += ["", f"A-koers: {race_name} ({race_date})"]
+    if phase_races:
+        lines.append("Wedstrijden in deze fase:")
+        for r in phase_races:
+            lines.append(f"  • {r['date']} — {r['name']} [{r.get('priority','C')}]")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# MCP tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def create_atp_plan(
+    race_date: str,
+    race_name: str,
+    goal_ctl: int,
+    recovery_cycle: int = 4,
+    additional_races: str | None = None,
+    athlete_id: str | None = None,
+    api_key: str | None = None,
+) -> str:
+    """Create an ATP (Annual Training Plan) in Intervals.icu for a goal race.
+
+    Fetches current CTL, compares it to goal_ctl, and automatically determines
+    which phases are needed and how long they should be. The bigger the gap
+    between current and goal CTL, the more base-building phases are added.
+
+    Phase selection (based on current CTL as % of goal CTL):
+    - ≥ 90% of goal: already close → Build → Peak → Race
+    - 70–90% of goal: moderate gap → Base → Build → Peak → Race
+    - < 70% of goal: large gap  → Preparation → Base → Build → Peak → Race
+
+    goal_ctl reference values (CTL needed at race day):
+    - Finish a sportive / gran fondo:        50–70
+    - Club-level amateur racer:              70–90
+    - Competitive amateur / cat. 3–4:        90–110
+    - Semi-pro / UCI belofte:               100–130
+    - Pro continental / WorldTour:          130+
+
+    Each phase is posted as a NOTE event spanning its full date range on the
+    Intervals.icu calendar. The note contains training focus, intensity split,
+    weekly TSS targets, key sessions, and recovery-week schedule.
+
+    Args:
+        race_date: Date of the A-race in YYYY-MM-DD format
+        race_name: Name of the A-race (e.g. "Ronde van Vlaanderen")
+        goal_ctl: Target CTL (fitness) needed at race day — see reference above
+        recovery_cycle: Recovery week every N weeks — 3 for older/less experienced
+                        athletes, 4 for younger/experienced athletes (default 4)
+        additional_races: Optional B/C races, one per line as
+                          "YYYY-MM-DD Name [A/B/C]"
+                          e.g. "2026-03-21 Dwars door V. C"
+        athlete_id: The Intervals.icu athlete ID (optional)
+        api_key: The Intervals.icu API key (optional)
+    """
+    athlete_id_to_use, error_msg = resolve_athlete_id(athlete_id, config.athlete_id)
+    if error_msg:
+        return error_msg
+
+    try:
+        validate_date(race_date)
+        race_dt = date.fromisoformat(race_date)
+    except ValueError as e:
+        return f"Error in race_date: {e}"
+
+    if recovery_cycle not in (3, 4):
+        return "Error: recovery_cycle must be 3 or 4."
+
+    today = date.today()
+    if race_dt <= today:
+        return f"Error: race_date {race_date} is in the past. Provide a future date."
+
+    today_monday = _monday_of(today)
+    race_monday = _monday_of(race_dt)
+    total_weeks = max(1, (race_monday - today_monday).days // 7 + 1)
+
+    # Fetch current CTL from wellness
+    wellness_result = await make_intervals_request(
+        url=f"/athlete/{athlete_id_to_use}/wellness",
+        api_key=api_key,
+        params={
+            "oldest": (today - timedelta(days=7)).isoformat(),
+            "newest": today.isoformat(),
+        },
+    )
+
+    current_ctl: float = 30.0  # fallback if no data
+    ctl_source = "onbekend (geen wellness-data)"
+    if isinstance(wellness_result, list) and wellness_result:
+        for entry in reversed(wellness_result):
+            if isinstance(entry, dict) and entry.get("ctl") is not None:
+                current_ctl = float(entry["ctl"])
+                ctl_source = f"{round(current_ctl, 1)} (uit wellness {entry.get('id', '')})"
+                break
+
+    # Weekly TSS in peak build weeks ≈ goal_ctl × 7
+    goal_weekly_tss = round(goal_ctl * 7 / 50) * 50
+
+    # Parse additional races
+    extra_races: list[dict] = []
+    if additional_races:
+        for line in additional_races.strip().splitlines():
+            parts = line.strip().split(None, 1)   # split on first space only: [date, rest]
+            if len(parts) == 2:
+                name_part = parts[1].strip()
+                priority = "C"
+                if "[" in name_part:
+                    priority = name_part.split("[")[-1].strip("] ").upper()
+                    name_part = name_part.split("[")[0].strip()
+                extra_races.append({"date": parts[0], "name": name_part, "priority": priority})
+
+    # Determine phases
+    phase_list = _determine_phases(total_weeks, current_ctl, float(goal_ctl))
+    reason = _reason_for_phases(current_ctl, float(goal_ctl), total_weeks)
+
+    # Calculate date ranges (forward from today)
+    cursor = today_monday
+    phase_ranges: list[dict[str, Any]] = []
+    for phase_name, wks in phase_list:
+        p_start = cursor
+        p_end = cursor + timedelta(weeks=wks) - timedelta(days=1)
+        if phase_name == "race":
+            p_end = race_monday + timedelta(days=6)
+        phase_ranges.append({"name": phase_name, "start": p_start, "end": p_end, "weeks": wks})
+        cursor = p_end + timedelta(days=1)
+
+    total_phases = len(phase_ranges)
+    posted_lines: list[str] = []
+
+    for i, ph in enumerate(phase_ranges, start=1):
+        phase_races = [r for r in extra_races if ph["start"].isoformat() <= r["date"] <= ph["end"].isoformat()]
+        description = _build_phase_note(
+            phase=ph["name"],
+            phase_num=i,
+            total_phases=total_phases,
+            start=ph["start"],
+            end=ph["end"],
+            cycle=recovery_cycle,
+            goal_tss=goal_weekly_tss,
+            race_name=race_name,
+            race_date=race_dt,
+            phase_races=phase_races,
+        )
+
+        event_data: dict[str, Any] = {
+            "category": "NOTE",
+            "name": f"ATP — {_PHASES[ph['name']]['label']}",
+            "description": description,
+            "start_date_local": ph["start"].isoformat() + "T00:00:00",
+            "end_date_local": ph["end"].isoformat() + "T00:00:00",
+            "color": _PHASES[ph["name"]]["color"],
+        }
+
+        result = await make_intervals_request(
+            url=f"/athlete/{athlete_id_to_use}/events",
+            api_key=api_key,
+            data=event_data,
+            method="POST",
+        )
+
+        label = _PHASES[ph["name"]]["label"]
+        if isinstance(result, dict) and "error" in result:
+            posted_lines.append(f"  ✗ {label} ({ph['start']} – {ph['end']}): {result.get('message')}")
+        else:
+            posted_lines.append(f"  ✓ {label}: {ph['start']} – {ph['end']} ({ph['weeks']} wk)")
+
+    phase_names = " → ".join(_PHASES[ph["name"]]["label"] for ph in phase_ranges)
+    summary = [
+        f"ATP aangemaakt voor {race_name} ({race_date})",
+        f"Periode: {today_monday} – {race_monday + timedelta(days=6)} ({total_weeks} weken)",
+        f"Huidige CTL: {ctl_source}",
+        f"Doel-CTL: {goal_ctl}  →  TSS-doel piekweek: ~{goal_weekly_tss}",
+        f"Reden fasekeuze: {reason}",
+        f"Fasen: {phase_names}",
+        f"Herstelcyclus: elke {recovery_cycle} weken",
+        "",
+        "Gepost op kalender:",
+    ] + posted_lines
+
+    return "\n".join(summary)
+
+
+@mcp.tool()
+async def get_atp_plan(
+    start_date: str | None = None,
+    end_date: str | None = None,
+    athlete_id: str | None = None,
+    api_key: str | None = None,
+) -> str:
+    """Read the current ATP plan from the Intervals.icu calendar.
+
+    Returns all ATP phase NOTE events in the given date range with their
+    training guidelines — a full season overview.
+
+    Args:
+        start_date: Start of range in YYYY-MM-DD format
+                    (optional, defaults to 3 months ago)
+        end_date: End of range in YYYY-MM-DD format
+                  (optional, defaults to 18 months from today)
+        athlete_id: The Intervals.icu athlete ID (optional)
+        api_key: The Intervals.icu API key (optional)
+    """
+    athlete_id_to_use, error_msg = resolve_athlete_id(athlete_id, config.athlete_id)
+    if error_msg:
+        return error_msg
+
+    today = date.today()
+    if not start_date:
+        start_date = (today - timedelta(days=90)).isoformat()
+    if not end_date:
+        end_date = (today + timedelta(days=550)).isoformat()
+
+    try:
+        validate_date(start_date)
+        validate_date(end_date)
+    except ValueError as e:
+        return f"Error: {e}"
+
+    result = await make_intervals_request(
+        url=f"/athlete/{athlete_id_to_use}/events",
+        api_key=api_key,
+        params={"oldest": start_date, "newest": end_date},
+    )
+
+    if isinstance(result, dict) and "error" in result:
+        return f"Error fetching ATP plan: {result.get('message')}"
+
+    events = result if isinstance(result, list) else []
+    notes = [e for e in events if e.get("category") == "NOTE"]
+
+    if not notes:
+        return (
+            f"Geen ATP-notities gevonden tussen {start_date} en {end_date}. "
+            "Gebruik create_atp_plan om een plan aan te maken."
+        )
+
+    lines = [f"ATP-overzicht ({start_date} – {end_date})\n"]
+    for note in notes:
+        name = note.get("name", "")
+        s = (note.get("start_date_local") or "")[:10]
+        e_end = (note.get("end_date_local") or note.get("start_date_local") or "")[:10]
+        desc = note.get("description", "")
+        lines.append(f"## {name}  ({s} – {e_end})")
+        if desc:
+            lines.append(desc)
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def get_atp_week_note(
+    week_date: str,
+    athlete_id: str | None = None,
+    api_key: str | None = None,
+) -> str:
+    """Get the ATP phase note covering the week that contains week_date.
+
+    Returns which phase the week falls in and its training guidelines
+    (focus, intensity, TSS target). Use this before planning a week's workouts.
+
+    Args:
+        week_date: Any date within the target week in YYYY-MM-DD format
+        athlete_id: The Intervals.icu athlete ID (optional)
+        api_key: The Intervals.icu API key (optional)
+    """
+    athlete_id_to_use, error_msg = resolve_athlete_id(athlete_id, config.athlete_id)
+    if error_msg:
+        return error_msg
+
+    try:
+        validate_date(week_date)
+    except ValueError as e:
+        return f"Error: {e}"
+
+    monday = _monday_of(date.fromisoformat(week_date))
+    sunday = monday + timedelta(days=6)
+
+    result = await make_intervals_request(
+        url=f"/athlete/{athlete_id_to_use}/events",
+        api_key=api_key,
+        params={"oldest": monday.isoformat(), "newest": sunday.isoformat()},
+    )
+
+    if isinstance(result, dict) and "error" in result:
+        return f"Error fetching events: {result.get('message')}"
+
+    events = result if isinstance(result, list) else []
+    notes = [e for e in events if e.get("category") == "NOTE"]
+
+    if not notes:
+        return (
+            f"Geen ATP-notitie gevonden voor week {monday} – {sunday}. "
+            "Gebruik create_atp_plan om het seizoen te structureren."
+        )
+
+    lines = [f"ATP voor week {monday} – {sunday}:\n"]
+    for note in notes:
+        name = note.get("name", "")
+        desc = note.get("description", "")
+        lines.append(f"### {name}\n{desc}" if name else desc)
+
+    return "\n\n".join(lines)
+
+
+@mcp.tool()
+async def get_planning_context(
+    week_date: str,
+    athlete_id: str | None = None,
+    api_key: str | None = None,
+) -> str:
+    """Get full planning context for a training week.
+
+    Returns in one call:
+    - The ATP phase note for this week (focus, TSS target, key sessions)
+    - Current fitness: CTL, ATL, TSB, HRV, ramp rate
+    - Workouts already scheduled this week
+    - Upcoming races (next 120 days)
+
+    Use this before planning the week's workouts, then use add_or_update_event
+    to post each day's workout.
+
+    Args:
+        week_date: Any date within the target week in YYYY-MM-DD format
+        athlete_id: The Intervals.icu athlete ID (optional)
+        api_key: The Intervals.icu API key (optional)
+    """
+    athlete_id_to_use, error_msg = resolve_athlete_id(athlete_id, config.athlete_id)
+    if error_msg:
+        return error_msg
+
+    try:
+        validate_date(week_date)
+    except ValueError as e:
+        return f"Error: {e}"
+
+    monday = _monday_of(date.fromisoformat(week_date))
+    sunday = monday + timedelta(days=6)
+    today = date.today()
+
+    wellness_result, week_events, races_result = await asyncio.gather(
+        make_intervals_request(
+            url=f"/athlete/{athlete_id_to_use}/wellness",
+            api_key=api_key,
+            params={
+                "oldest": (today - timedelta(days=14)).isoformat(),
+                "newest": today.isoformat(),
+            },
+        ),
+        make_intervals_request(
+            url=f"/athlete/{athlete_id_to_use}/events",
+            api_key=api_key,
+            params={"oldest": monday.isoformat(), "newest": sunday.isoformat()},
+        ),
+        make_intervals_request(
+            url=f"/athlete/{athlete_id_to_use}/events",
+            api_key=api_key,
+            params={
+                "oldest": today.isoformat(),
+                "newest": (today + timedelta(days=120)).isoformat(),
+            },
+        ),
+        return_exceptions=True,
+    )
+
+    # Unwrap any exceptions returned by gather (return_exceptions=True)
+    wellness_result = wellness_result if not isinstance(wellness_result, BaseException) else []
+    week_events = week_events if not isinstance(week_events, BaseException) else []
+    races_result = races_result if not isinstance(races_result, BaseException) else []
+
+    week_list = week_events if isinstance(week_events, list) else []
+    sections: list[str] = [f"# Planningcontext: week {monday} – {sunday}\n"]
+
+    # ATP phase note
+    sections.append("## ATP-fase")
+    atp_notes = [e for e in week_list if e.get("category") == "NOTE"]
+    if atp_notes:
+        for n in atp_notes:
+            name = n.get("name", "")
+            desc = n.get("description", "")
+            sections.append(f"**{name}**\n{desc}" if name else desc)
+    else:
+        sections.append(
+            "Geen ATP-notitie voor deze week. Gebruik create_atp_plan om het seizoen te structureren."
+        )
+
+    # Fitness
+    sections.append("\n## Conditie (afgelopen 14 dagen)")
+    if isinstance(wellness_result, list) and wellness_result:
+        latest = next((e for e in reversed(wellness_result) if isinstance(e, dict) and e.get("ctl") is not None), None)
+        if latest:
+            ctl = latest.get("ctl")
+            atl = latest.get("atl")
+            tsb = round(ctl - atl, 1) if ctl is not None and atl is not None else None
+            form = ""
+            if tsb is not None:
+                form = " (uitgerust)" if tsb > 10 else (" (vermoeid)" if tsb < -10 else " (neutraal)")
+            lines = []
+            if ctl is not None:
+                lines.append(f"CTL (fitness): {round(ctl, 1)}")
+            if atl is not None:
+                lines.append(f"ATL (vermoeidheid): {round(atl, 1)}")
+            if tsb is not None:
+                lines.append(f"TSB (vorm): {tsb}{form}")
+            hrv = latest.get("hrv")
+            if hrv is not None:
+                lines.append(f"HRV: {hrv}")
+            ramp = latest.get("rampRate")
+            if ramp is not None:
+                lines.append(f"Ramp rate: {round(ramp, 1)} CTL/week")
+            sections.append("\n".join(lines))
+        else:
+            sections.append("Geen CTL/ATL beschikbaar.")
+    else:
+        sections.append("Geen wellness-data beschikbaar.")
+
+    # Planned workouts
+    sections.append("\n## Geplande workouts deze week")
+    workouts = [e for e in week_list if e.get("category") == "WORKOUT"]
+    if workouts:
+        for w in workouts:
+            d = (w.get("start_date_local") or "")[:10]
+            name = w.get("name", "workout")
+            wtype = w.get("type", "")
+            mt = w.get("moving_time")
+            dur = f" ({int(mt) // 60} min)" if mt else ""
+            sections.append(f"- {d} [{wtype}] {name}{dur}")
+    else:
+        sections.append("Nog geen workouts ingepland.")
+
+    # Upcoming races
+    sections.append("\n## Komende wedstrijden (120 dagen)")
+    if isinstance(races_result, list) and races_result:
+        races = [e for e in races_result if e.get("category") in ("RACE", "A", "B", "C")]
+        if races:
+            for r in races:
+                d = (r.get("start_date_local") or "")[:10]
+                name = r.get("name", "wedstrijd")
+                cat = r.get("category", "")
+                sections.append(f"- {d}: {name} [{cat}]")
+        else:
+            sections.append("Geen wedstrijden gepland.")
+    else:
+        sections.append("Geen wedstrijden gepland.")
+
+    return "\n".join(sections)

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -13,7 +13,7 @@ athlete's current fitness level:
 """
 
 import asyncio
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from typing import Any
 
 from intervals_mcp_server.api.client import make_intervals_request
@@ -85,9 +85,10 @@ def _determine_phases(total_weeks: int, current_ctl: float, goal_ctl: float) -> 
     if total_weeks <= 1:
         return [("race", total_weeks)]
     race_wks = 1
-    peak_wks = min(2, max(1, (total_weeks - race_wks) // 7))
-    if peak_wks + race_wks >= total_weeks:
-        peak_wks = total_weeks - race_wks
+    remaining_after_race = total_weeks - race_wks
+    peak_wks = 2 if remaining_after_race >= 4 else 1
+    if peak_wks >= remaining_after_race:
+        peak_wks = remaining_after_race
     remaining = total_weeks - peak_wks - race_wks
 
     tail = [("peak", peak_wks), ("race", race_wks)]
@@ -166,12 +167,12 @@ def _weeks_in(start: date, end: date) -> int:
 
 
 
-def _week_tss(phase: str, goal_tss: int, week: int, cycle: int, load_weeks: list[int]) -> str:
+def _week_tss(phase: str, goal_tss: int, week: int, cycle: int, load_week_idx: dict[int, int]) -> str:
     factor = _PHASES[phase]["tss_factor"]
     if week % cycle == 0:
         return f"~{round(goal_tss * factor * 0.60 / 50) * 50} TSS  ← recovery week"
-    idx = load_weeks.index(week) if week in load_weeks else 0
-    prog = 0.85 + 0.15 * (idx / max(len(load_weeks) - 1, 1))
+    idx = load_week_idx.get(week, 0)
+    prog = 0.85 + 0.15 * (idx / max(len(load_week_idx) - 1, 1))
     tss = round(goal_tss * factor * prog / 50) * 50
     return f"~{tss} TSS"
 
@@ -190,7 +191,7 @@ def _build_phase_note(
 ) -> str:
     p = _PHASES[phase]
     total_wks = _weeks_in(start, end)
-    load_weeks = [w for w in range(1, total_wks + 1) if w % cycle != 0]
+    load_week_idx = {w: i for i, w in enumerate(w for w in range(1, total_wks + 1) if w % cycle != 0)}
 
     lines = [
         f"Phase {phase_num}/{total_phases}: {p['label']}",
@@ -206,7 +207,7 @@ def _build_phase_note(
     for w in range(1, total_wks + 1):
         w_start = start + timedelta(weeks=w - 1)
         w_end = min(w_start + timedelta(days=6), end)
-        lines.append(f"  Week {w} ({w_start} – {w_end}): {_week_tss(phase, goal_tss, w, cycle, load_weeks)}")
+        lines.append(f"  Week {w} ({w_start} – {w_end}): {_week_tss(phase, goal_tss, w, cycle, load_week_idx)}")
 
     lines += ["", f"A-race: {race_name} ({race_date})"]
     if phase_races:
@@ -315,7 +316,7 @@ async def create_atp_plan(
         for line in additional_races.strip().splitlines():
             parts = line.strip().split(None, 1)  # split on first space only: [date, rest]
             if len(parts) != 2:
-                continue
+                return f"Error: malformed additional_races line '{line.strip()}'. Expected format: 'YYYY-MM-DD Race name [A/B/C]'."
             raw_date, rest = parts[0], parts[1].strip()
             try:
                 validate_date(raw_date)
@@ -734,9 +735,8 @@ async def add_race_event(
     if priority_upper not in ("A", "B", "C"):
         return "Error: priority must be A, B, or C."
 
-    from datetime import datetime as _dt
     try:
-        _dt.strptime(start_time, "%H:%M:%S")
+        datetime.strptime(start_time, "%H:%M:%S")
     except ValueError:
         return "Error: start_time must be in HH:MM:SS format (e.g. '10:00:00')."
 

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -79,6 +79,11 @@ _PHASES: dict[str, dict[str, Any]] = {
 _ATP_PREFIX = "ATP — "
 _TRAILING_PRIORITY_RE = re.compile(r'^(.*?)\s*\[([A-Ca-c])\]\s*$')
 
+# Thresholds for aerobic basis assessment via 30-day power curve.
+# Adjust these constants to tune how strict the basis check is.
+_BASIS_20MIN_THRESHOLD: float = 0.85  # 20-min power must be >= ftp * this
+_BASIS_60MIN_THRESHOLD: float = 0.75  # 60-min power must be >= ftp * this
+
 
 def _is_atp_note(e: object) -> bool:
     return (
@@ -199,16 +204,79 @@ def _build_extra_sports_sections(phase: str, sports: list[str]) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Aerobic basis assessment via 30-day power curve
+# ---------------------------------------------------------------------------
+
+def _extract_30d_power(
+    curve_result: Any,
+) -> tuple[float | None, float | None]:
+    """Extract 20-min (1200 s) and 60-min (3600 s) best power from a power-curves API response."""
+    if not isinstance(curve_result, dict):
+        return None, None
+    curve_list: list[dict[str, Any]] = curve_result.get("list", [])
+    if not curve_list:
+        return None, None
+    curve = curve_list[0]
+    secs: list[int] = curve.get("secs", [])
+    values: list[Any] = curve.get("values", [])
+    sec_to_idx = {s: i for i, s in enumerate(secs)}
+
+    def _get(duration: int) -> float | None:
+        idx = sec_to_idx.get(duration)
+        if idx is None or idx >= len(values):
+            return None
+        v = values[idx]
+        return float(v) if v is not None else None
+
+    return _get(1200), _get(3600)
+
+
+def _assess_basis(
+    power_20min: float | None,
+    power_60min: float | None,
+    ftp: int | None,
+) -> tuple[bool | None, float | None, float | None, float | None]:
+    """Determine whether the aerobic basis is present from the 30-day power curve.
+
+    Returns (basis_present, ftp_ref, ratio_20min, ratio_60min).
+    basis_present=None means insufficient data to make a determination.
+    """
+    if power_20min is None and power_60min is None:
+        return None, None, None, None
+
+    ftp_ref: float
+    if ftp is not None:
+        ftp_ref = float(ftp)
+    elif power_20min is not None:
+        ftp_ref = power_20min * 0.95  # standard 20-min proxy
+    else:
+        return None, None, None, None
+
+    ratio_20 = power_20min / ftp_ref if power_20min is not None else None
+    ratio_60 = power_60min / ftp_ref if power_60min is not None else None
+
+    meets_20 = ratio_20 is not None and ratio_20 >= _BASIS_20MIN_THRESHOLD
+    meets_60 = ratio_60 is not None and ratio_60 >= _BASIS_60MIN_THRESHOLD
+    return meets_20 and meets_60, ftp_ref, ratio_20, ratio_60
+
+
+# ---------------------------------------------------------------------------
 # Phase auto-selection logic (relative to goal CTL, not absolute thresholds)
 # ---------------------------------------------------------------------------
 
 
-def _determine_phases(total_weeks: int, current_ctl: float, goal_ctl: float) -> list[tuple[str, int]]:
-    """Return ordered (phase_name, weeks) based on available weeks and CTL gap.
+def _determine_phases(
+    total_weeks: int,
+    current_ctl: float,
+    goal_ctl: float,
+    basis_present: bool | None = None,
+) -> list[tuple[str, int]]:
+    """Return ordered (phase_name, weeks) based on available weeks, CTL gap, and aerobic basis.
 
-    Uses the ratio current_ctl / goal_ctl so thresholds scale with the event:
-    - UCI u23 rider targeting CTL 110 with current 70 → big gap → needs base
-    - Gran fondo finisher targeting CTL 60 with current 50 → small gap → straight to build
+    basis_present=True  → skip or shorten Base when power curve shows the athlete
+                          has been riding at threshold level in the last 30 days.
+    basis_present=False → add Base even when CTL ratio would normally skip it.
+    basis_present=None  → fall back to CTL-gap-only logic (original behaviour).
     """
     if total_weeks <= 1:
         return [("race", total_weeks)]
@@ -226,8 +294,36 @@ def _determine_phases(total_weeks: int, current_ctl: float, goal_ctl: float) -> 
 
     ratio = current_ctl / max(goal_ctl, 1.0)
 
-    if remaining <= 4 or ratio >= 0.90:
-        # Almost at goal CTL or very little time → straight to build
+    # Short plans: always collapse to pure build regardless of basis signal
+    if remaining <= 4:
+        return [("build", remaining)] + tail
+
+    # ---- Basis-aware branch ----------------------------------------
+    if basis_present is True:
+        if ratio >= 0.70:
+            # Basis confirmed + CTL close enough → skip base, go straight to build
+            return [("build", remaining)] + tail
+        else:
+            # Big CTL gap but basis is there → short base to ramp volume, then build
+            base_wks = max(2, remaining // 4)
+            build_wks = remaining - base_wks
+            if build_wks < 3:
+                return [("build", remaining)] + tail
+            return [("base", base_wks), ("build", build_wks)] + tail
+
+    if basis_present is False:
+        if ratio >= 0.70:
+            # CTL looks fine but no recent riding → add a base block anyway
+            base_wks = max(3, remaining // 3)
+            build_wks = remaining - base_wks
+            if build_wks < 3:
+                return [("build", remaining)] + tail
+            return [("base", base_wks), ("build", build_wks)] + tail
+        # ratio < 0.70 falls through to the original large-gap logic below
+
+    # ---- Original CTL-gap-only logic (basis_present=None, or False+large gap) --
+    if ratio >= 0.90:
+        # Almost at goal CTL → straight to build
         return [("build", remaining)] + tail
 
     if ratio >= 0.70:
@@ -248,7 +344,6 @@ def _determine_phases(total_weeks: int, current_ctl: float, goal_ctl: float) -> 
         base_wks = max(3, remaining // 2)
         build_wks = remaining - base_wks
         if build_wks < 3:
-            # remaining too small for both base and build — collapse to pure build
             return [("build", remaining)] + tail
 
     phases: list[tuple[str, int]] = []
@@ -261,34 +356,63 @@ def _determine_phases(total_weeks: int, current_ctl: float, goal_ctl: float) -> 
     return phases + tail
 
 
-def _reason_for_phases(current_ctl: float, goal_ctl: float, total_weeks: int) -> str:
-    ratio = current_ctl / max(goal_ctl, 1.0)
+def _phase_selection_summary(
+    current_ctl: float,
+    goal_ctl: float,
+    total_weeks: int,
+    phase_list: list[tuple[str, int]],
+    power_20min: float | None = None,
+    power_60min: float | None = None,
+    ftp_ref: float | None = None,
+    ratio_20min: float | None = None,
+    ratio_60min: float | None = None,
+    basis_present: bool | None = None,
+) -> str:
+    """Return a multi-line phase-selection explanation for the tool summary."""
     goal_ctl_int = round(goal_ctl)
     current_ctl_int = round(current_ctl)
     gap = goal_ctl_int - current_ctl_int
-    if total_weeks <= 5:
-        phases = _determine_phases(total_weeks, current_ctl, goal_ctl)
-        phase_seq = " → ".join(_PHASES[name]["label"] for name, _ in phases)
-        return f"Only {total_weeks} weeks available — {phase_seq}."
-    if gap <= 0:
-        return (
-            f"CTL {current_ctl_int} already meets or exceeds goal CTL {goal_ctl_int} "
-            f"— going straight to build phase."
+    phase_seq = " → ".join(_PHASES[name]["label"] for name, _ in phase_list)
+
+    lines = [
+        f"  Current CTL: {current_ctl_int} (goal: {goal_ctl_int}, gap: {gap} pts)",
+    ]
+
+    # Power curve line
+    if power_20min is None and power_60min is None:
+        lines.append("  Power curve (last 30 days): no recent data (last activity > 30 days ago)")
+    else:
+        ftp_str = f" | FTP ref: {round(ftp_ref)}W" if ftp_ref is not None else ""
+        p20_str = (
+            f"20min = {round(power_20min)}W ({round(ratio_20min * 100)}% of FTP ref)"
+            if power_20min is not None and ratio_20min is not None
+            else "20min = n/a"
         )
-    if ratio >= 0.90:
-        return (
-            f"CTL {current_ctl_int} is close to goal CTL {goal_ctl_int} "
-            f"(gap: {gap}) — going straight to build phase."
+        p60_str = (
+            f"60min = {round(power_60min)}W ({round(ratio_60min * 100)}% of FTP ref)"
+            if power_60min is not None and ratio_60min is not None
+            else "60min = n/a"
         )
-    if ratio >= 0.70:
-        return (
-            f"CTL {current_ctl_int} is {gap} points below goal CTL {goal_ctl_int} "
-            f"({round(ratio * 100)}%) — short base block followed by build phase."
+        lines.append(f"  Power curve (last 30 days): {p20_str}, {p60_str}{ftp_str}")
+
+    # Basis assessment line
+    if basis_present is True:
+        lines.append(
+            f"  Basis assessment: PRESENT — strong 20min and 60min values in last 30 days"
         )
-    return (
-        f"CTL {current_ctl_int} is {gap} points below goal CTL {goal_ctl_int} "
-        f"({round(ratio * 100)}%) — preparation and base block needed before build."
-    )
+    elif basis_present is False:
+        if power_20min is None and power_60min is None:
+            lines.append("  Basis assessment: ABSENT — no recent riding detected")
+        else:
+            lines.append(
+                f"  Basis assessment: ABSENT — 20min/60min below threshold "
+                f"(need ≥{round(_BASIS_20MIN_THRESHOLD * 100)}% / ≥{round(_BASIS_60MIN_THRESHOLD * 100)}% of FTP ref)"
+            )
+    else:
+        lines.append("  Basis assessment: N/A — no power curve data, using CTL-gap only")
+
+    lines.append(f"  Decision: {phase_seq}")
+    return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------
@@ -493,14 +617,28 @@ async def create_atp_plan(
     race_monday = _monday_of(race_dt)
     total_weeks = max(1, (race_monday - today_monday).days // 7 + 1)
 
-    # Fetch current CTL from wellness
-    wellness_result = await make_intervals_request(
-        url=f"/athlete/{athlete_id_to_use}/wellness",
-        api_key=api_key,
-        params={
-            "oldest": (today - timedelta(days=7)).isoformat(),
-            "newest": today.isoformat(),
-        },
+    # Fetch CTL (wellness) and 30-day power curve in parallel
+    curve_start = (today - timedelta(days=30)).isoformat()
+    curve_end = today.isoformat()
+    wellness_result, curve_result = await asyncio.gather(
+        make_intervals_request(
+            url=f"/athlete/{athlete_id_to_use}/wellness",
+            api_key=api_key,
+            params={
+                "oldest": (today - timedelta(days=7)).isoformat(),
+                "newest": today.isoformat(),
+            },
+        ),
+        make_intervals_request(
+            url=f"/athlete/{athlete_id_to_use}/power-curves",
+            api_key=api_key,
+            params={
+                "curves": [f"r.{curve_start}.{curve_end}"],
+                "type": "Ride",
+                "includeRanks": False,
+            },
+        ),
+        return_exceptions=True,
     )
 
     current_ctl: float = 30.0  # fallback if no data
@@ -511,6 +649,13 @@ async def create_atp_plan(
                 current_ctl = float(entry["ctl"])
                 ctl_source = f"{round(current_ctl, 1)} (from wellness {entry.get('id', '')})"
                 break
+
+    # Assess aerobic basis from power curve; fall back gracefully on any error
+    power_20min: float | None = None
+    power_60min: float | None = None
+    if not isinstance(curve_result, Exception):
+        power_20min, power_60min = _extract_30d_power(curve_result)
+    basis_present, ftp_ref, ratio_20min, ratio_60min = _assess_basis(power_20min, power_60min, ftp)
 
     # Weekly TSS in peak build weeks ≈ goal_ctl × 7
     goal_weekly_tss = max(50, round(goal_ctl * 7 / 50) * 50)
@@ -576,9 +721,20 @@ async def create_atp_plan(
                 method="DELETE",
             )
 
-    # Determine phases
-    phase_list = _determine_phases(total_weeks, current_ctl, float(goal_ctl))
-    reason = _reason_for_phases(current_ctl, float(goal_ctl), total_weeks)
+    # Determine phases (basis_present=None falls back to CTL-gap-only logic)
+    phase_list = _determine_phases(total_weeks, current_ctl, float(goal_ctl), basis_present)
+    phase_selection = _phase_selection_summary(
+        current_ctl=current_ctl,
+        goal_ctl=float(goal_ctl),
+        total_weeks=total_weeks,
+        phase_list=phase_list,
+        power_20min=power_20min,
+        power_60min=power_60min,
+        ftp_ref=ftp_ref,
+        ratio_20min=ratio_20min,
+        ratio_60min=ratio_60min,
+        basis_present=basis_present,
+    )
 
     # Calculate date ranges (forward from today)
     cursor = today_monday
@@ -670,7 +826,7 @@ async def create_atp_plan(
         f"Period: {today_monday} – {race_monday + timedelta(days=6)} ({total_weeks} weeks)",
         f"Current CTL: {ctl_source}",
         f"Goal CTL: {goal_ctl}  →  Peak week TSS target: ~{goal_weekly_tss}{tss_sport_note}{tss_hours_note}",
-        f"Phase selection: {reason}",
+        f"Phase selection:\n{phase_selection}",
         f"Phases: {phase_names}",
         f"Recovery cycle: every {recovery_cycle} weeks",
     ]

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -361,13 +361,22 @@ async def create_atp_plan(
         api_key=api_key,
         params={"oldest": today_monday.isoformat(), "newest": plan_end.isoformat()},
     )
-    for ev in (existing if isinstance(existing, list) else []):
-        if _is_atp_note(ev) and isinstance(ev, dict) and ev.get("id"):
+    _sem = asyncio.Semaphore(3)
+
+    async def _delete(ev_id: str) -> None:
+        async with _sem:
             await make_intervals_request(
-                url=f"/athlete/{athlete_id_to_use}/events/{ev['id']}",
+                url=f"/athlete/{athlete_id_to_use}/events/{ev_id}",
                 api_key=api_key,
                 method="DELETE",
             )
+
+    to_delete = [
+        ev["id"] for ev in (existing if isinstance(existing, list) else [])
+        if _is_atp_note(ev) and isinstance(ev, dict) and ev.get("id")
+    ]
+    if to_delete:
+        await asyncio.gather(*(_delete(ev_id) for ev_id in to_delete))
 
     # Determine phases
     phase_list = _determine_phases(total_weeks, current_ctl, float(goal_ctl))
@@ -385,8 +394,9 @@ async def create_atp_plan(
         cursor = p_end + timedelta(days=1)
 
     total_phases = len(phase_ranges)
-    posted_lines: list[str] = []
 
+    # Build all event payloads up front (pure computation, no I/O)
+    phase_events: list[tuple[dict[str, Any], dict[str, Any]]] = []
     for i, ph in enumerate(phase_ranges, start=1):
         phase_races = [r for r in extra_races if ph["start"].isoformat() <= r["date"] <= ph["end"].isoformat()]
         description = _build_phase_note(
@@ -401,7 +411,6 @@ async def create_atp_plan(
             race_date=race_dt,
             phase_races=phase_races,
         )
-
         event_data: dict[str, Any] = {
             "category": "NOTE",
             "name": f"ATP — {_PHASES[ph['name']]['label']}",
@@ -410,14 +419,35 @@ async def create_atp_plan(
             "end_date_local": (ph["end"] + timedelta(days=1)).isoformat() + "T00:00:00",
             "color": _PHASES[ph["name"]]["color"],
         }
+        phase_events.append((ph, event_data))
 
-        result = await make_intervals_request(
-            url=f"/athlete/{athlete_id_to_use}/events",
-            api_key=api_key,
-            data=event_data,
-            method="POST",
-        )
+    async def _post_phase(ph: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        async with _sem:
+            return await make_intervals_request(
+                url=f"/athlete/{athlete_id_to_use}/events",
+                api_key=api_key,
+                data=data,
+                method="POST",
+            )
 
+    post_results = await asyncio.gather(
+        *(_post_phase(ph, ev) for ph, ev in phase_events),
+        return_exceptions=True,
+    )
+
+    # Rollback any created events if a failure occurred
+    created_ids = [
+        r["id"] for r in post_results
+        if isinstance(r, dict) and "id" in r and "error" not in r
+    ]
+    failed = [r for r in post_results if isinstance(r, Exception) or (isinstance(r, dict) and "error" in r)]
+    if failed:
+        await asyncio.gather(*(_delete(ev_id) for ev_id in created_ids))
+        err_msg = failed[0].get("message") if isinstance(failed[0], dict) else str(failed[0])
+        return f"Error creating ATP plan (all changes rolled back): {err_msg}"
+
+    posted_lines: list[str] = []
+    for (ph, _), result in zip(phase_events, post_results):
         label = _PHASES[ph["name"]]["label"]
         if isinstance(result, dict) and "error" in result:
             posted_lines.append(f"  ✗ {label} ({ph['start']} – {ph['end']}): {result.get('message')}")
@@ -636,16 +666,18 @@ async def get_planning_context(
     _api_warnings: list[str] = []
     _labels = ("wellness", "week events", "upcoming races")
     for _label, _raw_item in zip(_labels, _raw):
-        if isinstance(_raw_item, BaseException):
+        if isinstance(_raw_item, asyncio.CancelledError):
+            raise _raw_item
+        if isinstance(_raw_item, Exception):
             _api_warnings.append(f"  • {_label}: {_raw_item}")
     wellness_result: dict[str, Any] | list[dict[str, Any]] = (
-        _raw[0] if not isinstance(_raw[0], BaseException) else _fallback
+        _raw[0] if not isinstance(_raw[0], Exception) else _fallback
     )
     week_events: dict[str, Any] | list[dict[str, Any]] = (
-        _raw[1] if not isinstance(_raw[1], BaseException) else _fallback
+        _raw[1] if not isinstance(_raw[1], Exception) else _fallback
     )
     races_result: dict[str, Any] | list[dict[str, Any]] = (
-        _raw[2] if not isinstance(_raw[2], BaseException) else _fallback
+        _raw[2] if not isinstance(_raw[2], Exception) else _fallback
     )
 
     week_list = week_events if isinstance(week_events, list) else []

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -84,10 +84,6 @@ _TRAILING_PRIORITY_RE = re.compile(r'^(.*?)\s*\[([A-Ca-c])\]\s*$')
 _BASIS_20MIN_THRESHOLD: float = 0.85  # 20-min power must be >= ftp * this
 _BASIS_60MIN_THRESHOLD: float = 0.75  # 60-min power must be >= ftp * this
 
-# CTL-ratio thresholds used inside the basis_present=True branch.
-_BASE_SKIP_RATIO: float = 0.70   # at or above: skip Base entirely → straight to Build
-_BASE_SHORT_RATIO: float = 0.50  # at or above (but below SKIP): 2-week Base, then Build
-
 
 def _is_atp_note(e: object) -> bool:
     return (
@@ -304,35 +300,10 @@ def _determine_phases(
 
     # ---- Basis-aware branch ----------------------------------------
     if basis_present is True:
-        if ratio >= _BASE_SKIP_RATIO:
-            # Strong basis + small CTL gap → skip Base entirely
-            return [("build", remaining)] + tail
-        elif ratio >= _BASE_SHORT_RATIO:
-            # Strong basis but moderate CTL gap → fixed 2-week Base for volume ramp
-            base_wks = 2
-            build_wks = remaining - base_wks
-            if build_wks < 3:
-                return [("build", remaining)] + tail
-            return [("base", base_wks), ("build", build_wks)] + tail
-        else:
-            # Strong basis but very large CTL gap → full Base (Preparation not needed)
-            base_wks = max(3, remaining // 3)
-            build_wks = remaining - base_wks
-            if build_wks < 3:
-                return [("build", remaining)] + tail
-            return [("base", base_wks), ("build", build_wks)] + tail
+        # Powercurve is leading: basis confirmed → skip Base regardless of CTL gap
+        return [("build", remaining)] + tail
 
-    if basis_present is False:
-        if ratio >= 0.70:
-            # CTL looks fine but no recent riding → add a base block anyway
-            base_wks = max(3, remaining // 3)
-            build_wks = remaining - base_wks
-            if build_wks < 3:
-                return [("build", remaining)] + tail
-            return [("base", base_wks), ("build", build_wks)] + tail
-        # ratio < 0.70 falls through to the original large-gap logic below
-
-    # ---- Original CTL-gap-only logic (basis_present=None, or False+large gap) --
+    # ---- CTL-gap logic (basis absent or no powercurve data) --------
     if ratio >= 0.90:
         # Almost at goal CTL → straight to build
         return [("build", remaining)] + tail
@@ -367,15 +338,16 @@ def _determine_phases(
     return phases + tail
 
 
-def _basis_decision_note(basis_present: bool | None, ratio: float) -> str | None:
-    """Return a short descriptive prefix for the Decision line, or None for the default."""
-    if basis_present is not True:
-        return None
-    if ratio >= _BASE_SKIP_RATIO:
-        return "skipping Base entirely"
-    if ratio >= _BASE_SHORT_RATIO:
-        return "basis present, CTL gap large → short Base (2 wk)"
-    return "basis present, CTL gap very large → full Base, no Preparation"
+def _basis_decision_note(basis_present: bool | None, ratio: float) -> str:
+    """Return a short descriptive prefix for the Decision line."""
+    if basis_present is True:
+        return "basis present (powercurve) → skipping Base"
+    # Basis absent or no powercurve data — ratio is the deciding signal
+    if ratio >= 0.90:
+        return "no powercurve signal, CTL gap small"
+    if ratio >= 0.70:
+        return "no powercurve signal, moderate CTL gap"
+    return "no powercurve signal, large CTL gap"
 
 
 def _phase_selection_summary(
@@ -433,8 +405,7 @@ def _phase_selection_summary(
         lines.append("  Basis assessment: N/A — no power curve data, using CTL-gap only")
 
     note = _basis_decision_note(basis_present, ratio)
-    decision = f"{note} → {phase_seq}" if note else phase_seq
-    lines.append(f"  Decision: {decision}")
+    lines.append(f"  Decision: {note} → {phase_seq}")
     return "\n".join(lines)
 
 

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -70,6 +70,17 @@ _PHASES: dict[str, dict[str, Any]] = {
     },
 }
 
+_ATP_PREFIX = "ATP"
+
+
+def _is_atp_note(e: object) -> bool:
+    return (
+        isinstance(e, dict)
+        and e.get("category") == "NOTE"  # type: ignore[union-attr]
+        and (e.get("name") or "").startswith(_ATP_PREFIX)  # type: ignore[union-attr]
+    )
+
+
 # ---------------------------------------------------------------------------
 # Phase auto-selection logic (relative to goal CTL, not absolute thresholds)
 # ---------------------------------------------------------------------------
@@ -133,23 +144,30 @@ def _determine_phases(total_weeks: int, current_ctl: float, goal_ctl: float) -> 
 
 def _reason_for_phases(current_ctl: float, goal_ctl: float, total_weeks: int) -> str:
     ratio = current_ctl / max(goal_ctl, 1.0)
-    gap = round(goal_ctl - current_ctl)
+    goal_ctl_int = round(goal_ctl)
+    current_ctl_int = round(current_ctl)
+    gap = goal_ctl_int - current_ctl_int
     if total_weeks <= 5:
         phases = _determine_phases(total_weeks, current_ctl, goal_ctl)
         phase_seq = " → ".join(_PHASES[name]["label"] for name, _ in phases)
         return f"Only {total_weeks} weeks available — {phase_seq}."
+    if gap <= 0:
+        return (
+            f"CTL {current_ctl_int} already meets or exceeds goal CTL {goal_ctl_int} "
+            f"— going straight to build phase."
+        )
     if ratio >= 0.90:
         return (
-            f"CTL {round(current_ctl)} is close to goal CTL {goal_ctl} "
+            f"CTL {current_ctl_int} is close to goal CTL {goal_ctl_int} "
             f"(gap: {gap}) — going straight to build phase."
         )
     if ratio >= 0.70:
         return (
-            f"CTL {round(current_ctl)} is {gap} points below goal CTL {goal_ctl} "
+            f"CTL {current_ctl_int} is {gap} points below goal CTL {goal_ctl_int} "
             f"({round(ratio * 100)}%) — short base block followed by build phase."
         )
     return (
-        f"CTL {round(current_ctl)} is {gap} points below goal CTL {goal_ctl} "
+        f"CTL {current_ctl_int} is {gap} points below goal CTL {goal_ctl_int} "
         f"({round(ratio * 100)}%) — preparation and base block needed before build."
     )
 
@@ -331,6 +349,21 @@ async def create_atp_plan(
                 return f"Error: invalid priority '{priority}' for race '{name_part}'. Use A, B or C."
             extra_races.append({"date": raw_date, "name": name_part, "priority": priority})
 
+    # Delete any existing ATP notes in the plan window to avoid duplicates
+    plan_end = _monday_of(race_dt) + timedelta(days=6)
+    existing = await make_intervals_request(
+        url=f"/athlete/{athlete_id_to_use}/events",
+        api_key=api_key,
+        params={"oldest": today_monday.isoformat(), "newest": plan_end.isoformat()},
+    )
+    for ev in (existing if isinstance(existing, list) else []):
+        if _is_atp_note(ev) and isinstance(ev, dict) and ev.get("id"):
+            await make_intervals_request(
+                url=f"/athlete/{athlete_id_to_use}/events/{ev['id']}",
+                api_key=api_key,
+                method="DELETE",
+            )
+
     # Determine phases
     phase_list = _determine_phases(total_weeks, current_ctl, float(goal_ctl))
     reason = _reason_for_phases(current_ctl, float(goal_ctl), total_weeks)
@@ -450,7 +483,7 @@ async def get_atp_plan(
     events = result if isinstance(result, list) else []
     notes = [
         e for e in events
-        if isinstance(e, dict) and e.get("category") == "NOTE" and (e.get("name") or "").startswith("ATP")
+        if _is_atp_note(e)
     ]
 
     if not notes:
@@ -517,7 +550,7 @@ async def get_atp_week_note(
     events = result if isinstance(result, list) else []
     notes = [
         e for e in events
-        if isinstance(e, dict) and e.get("category") == "NOTE" and (e.get("name") or "").startswith("ATP")
+        if _is_atp_note(e)
     ]
 
     if not notes:
@@ -612,7 +645,7 @@ async def get_planning_context(
     sections.append("## ATP phase")
     atp_notes = [
         e for e in week_list
-        if isinstance(e, dict) and e.get("category") == "NOTE" and (e.get("name") or "").startswith("ATP")
+        if _is_atp_note(e)
     ]
     if atp_notes:
         for n in atp_notes:

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -82,8 +82,12 @@ def _determine_phases(total_weeks: int, current_ctl: float, goal_ctl: float) -> 
     - UCI u23 rider targeting CTL 110 with current 70 → big gap → needs base
     - Gran fondo finisher targeting CTL 60 with current 50 → small gap → straight to build
     """
-    peak_wks = min(2, max(1, total_weeks // 7))
+    if total_weeks <= 1:
+        return [("race", total_weeks)]
     race_wks = 1
+    peak_wks = min(2, max(1, (total_weeks - race_wks) // 7))
+    if peak_wks + race_wks >= total_weeks:
+        peak_wks = total_weeks - race_wks
     remaining = total_weeks - peak_wks - race_wks
 
     tail = [("peak", peak_wks), ("race", race_wks)]
@@ -458,7 +462,11 @@ async def get_atp_plan(
     for note in notes:
         name = note.get("name", "")
         s = (note.get("start_date_local") or "")[:10]
-        e_end = (note.get("end_date_local") or note.get("start_date_local") or "")[:10]
+        e_end_raw = (note.get("end_date_local") or note.get("start_date_local") or "")[:10]
+        try:
+            e_end = (date.fromisoformat(e_end_raw) - timedelta(days=1)).isoformat() if e_end_raw else ""
+        except ValueError:
+            e_end = e_end_raw
         desc = note.get("description", "")
         lines.append(f"## {name}  ({s} – {e_end})")
         if desc:
@@ -603,7 +611,7 @@ async def get_planning_context(
     sections.append("## ATP phase")
     atp_notes = [
         e for e in week_list
-        if e.get("category") == "NOTE" and (e.get("name") or "").startswith("ATP")
+        if isinstance(e, dict) and e.get("category") == "NOTE" and (e.get("name") or "").startswith("ATP")
     ]
     if atp_notes:
         for n in atp_notes:
@@ -650,7 +658,7 @@ async def get_planning_context(
 
     # Planned workouts
     sections.append("\n## Planned workouts this week")
-    workouts = [e for e in week_list if e.get("category") == "WORKOUT"]
+    workouts = [e for e in week_list if isinstance(e, dict) and e.get("category") == "WORKOUT"]
     if workouts:
         for w in workouts:
             d = (w.get("start_date_local") or "")[:10]
@@ -665,7 +673,7 @@ async def get_planning_context(
     # Upcoming races
     sections.append("\n## Upcoming races (120 days)")
     if isinstance(races_result, list) and races_result:
-        races = [e for e in races_result if e.get("category") in ("RACE_A", "RACE_B", "RACE_C")]
+        races = [e for e in races_result if isinstance(e, dict) and e.get("category") in ("RACE_A", "RACE_B", "RACE_C")]
         if races:
             for r in races:
                 d = (r.get("start_date_local") or "")[:10]

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -13,6 +13,7 @@ athlete's current fitness level:
 """
 
 import asyncio
+import re
 from datetime import date, datetime, timedelta
 from typing import Any
 
@@ -295,6 +296,9 @@ async def create_atp_plan(
     except ValueError as e:
         return f"Error in race_date: {e}"
 
+    if goal_ctl < 1:
+        return "Error: goal_ctl must be at least 1."
+
     if recovery_cycle not in (3, 4):
         return "Error: recovery_cycle must be 3 or 4."
 
@@ -331,8 +335,11 @@ async def create_atp_plan(
     # Parse additional races
     extra_races: list[dict] = []
     if additional_races:
+        _trailing_priority = re.compile(r'^(.*?)\s*\[([A-Ca-c])\]\s*$')
         for line in additional_races.strip().splitlines():
-            parts = line.strip().split(None, 1)  # split on first space only: [date, rest]
+            if not line.strip():
+                continue
+            parts = line.strip().split(None, 1)  # split on first whitespace: [date, rest]
             if len(parts) != 2:
                 return f"Error: malformed additional_races line '{line.strip()}'. Expected format: 'YYYY-MM-DD Race name [A/B/C]'."
             raw_date, rest = parts[0], parts[1].strip()
@@ -340,13 +347,11 @@ async def create_atp_plan(
                 validate_date(raw_date)
             except ValueError:
                 return f"Error: invalid date '{raw_date}' in additional_races. Use YYYY-MM-DD."
-            priority = "C"
-            name_part = rest
-            if "[" in rest:
-                priority = rest.split("[")[-1].strip("] ").upper()
-                name_part = rest.split("[")[0].strip()
-            if priority not in ("A", "B", "C"):
-                return f"Error: invalid priority '{priority}' for race '{name_part}'. Use A, B or C."
+            m = _trailing_priority.match(rest)
+            if m:
+                name_part, priority = m.group(1).strip(), m.group(2).upper()
+            else:
+                name_part, priority = rest, "C"
             extra_races.append({"date": raw_date, "name": name_part, "priority": priority})
 
     # Delete any existing ATP notes in the plan window to avoid duplicates
@@ -628,6 +633,11 @@ async def get_planning_context(
         return_exceptions=True,
     )
     _fallback: list[Any] = []
+    _api_warnings: list[str] = []
+    _labels = ("wellness", "week events", "upcoming races")
+    for _label, _raw_item in zip(_labels, _raw):
+        if isinstance(_raw_item, BaseException):
+            _api_warnings.append(f"  • {_label}: {_raw_item}")
     wellness_result: dict[str, Any] | list[dict[str, Any]] = (
         _raw[0] if not isinstance(_raw[0], BaseException) else _fallback
     )
@@ -718,6 +728,10 @@ async def get_planning_context(
             sections.append("No races scheduled.")
     else:
         sections.append("No races scheduled.")
+
+    if _api_warnings:
+        sections.append("\n## ⚠ API fetch warnings (data may be incomplete)")
+        sections.extend(_api_warnings)
 
     return "\n".join(sections)
 

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -71,7 +71,7 @@ _PHASES: dict[str, dict[str, Any]] = {
     },
 }
 
-_ATP_PREFIX = "ATP"
+_ATP_PREFIX = "ATP — "
 
 
 def _is_atp_note(e: object) -> bool:
@@ -330,7 +330,7 @@ async def create_atp_plan(
                 break
 
     # Weekly TSS in peak build weeks ≈ goal_ctl × 7
-    goal_weekly_tss = round(goal_ctl * 7 / 50) * 50
+    goal_weekly_tss = max(50, round(goal_ctl * 7 / 50) * 50)
 
     # Parse additional races
     extra_races: list[dict] = []
@@ -443,16 +443,14 @@ async def create_atp_plan(
     failed = [r for r in post_results if isinstance(r, Exception) or (isinstance(r, dict) and "error" in r)]
     if failed:
         await asyncio.gather(*(_delete(ev_id) for ev_id in created_ids))
-        err_msg = failed[0].get("message") if isinstance(failed[0], dict) else str(failed[0])
+        f = failed[0]
+        err_msg = (f.get("message") or f.get("error") or str(f)) if isinstance(f, dict) else str(f)
         return f"Error creating ATP plan (all changes rolled back): {err_msg}"
 
     posted_lines: list[str] = []
-    for (ph, _), result in zip(phase_events, post_results):
+    for (ph, _), _ in zip(phase_events, post_results):
         label = _PHASES[ph["name"]]["label"]
-        if isinstance(result, dict) and "error" in result:
-            posted_lines.append(f"  ✗ {label} ({ph['start']} – {ph['end']}): {result.get('message')}")
-        else:
-            posted_lines.append(f"  ✓ {label}: {ph['start']} – {ph['end']} ({ph['weeks']} wk)")
+        posted_lines.append(f"  ✓ {label}: {ph['start']} – {ph['end']} ({ph['weeks']} wk)")
 
     phase_names = " → ".join(_PHASES[ph["name"]]["label"] for ph in phase_ranges)
     summary = [

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -114,7 +114,7 @@ def _determine_phases(total_weeks: int, current_ctl: float, goal_ctl: float) -> 
         prep_wks = 0
         base_wks = max(3, remaining // 2)
         build_wks = remaining - base_wks
-        if build_wks < 1:
+        if build_wks < 3:
             # remaining too small for both base and build — collapse to pure build
             return [("build", remaining)] + tail
 
@@ -158,9 +158,6 @@ def _monday_of(d: date) -> date:
 def _weeks_in(start: date, end: date) -> int:
     return max(1, ((end - start).days + 1 + 6) // 7)
 
-
-def _recovery_week_numbers(total_weeks: int, cycle: int) -> list[int]:
-    return [w for w in range(1, total_weeks + 1) if w % cycle == 0]
 
 
 def _week_tss(phase: str, goal_tss: int, week: int, total_weeks: int, cycle: int) -> str:
@@ -311,13 +308,21 @@ async def create_atp_plan(
     if additional_races:
         for line in additional_races.strip().splitlines():
             parts = line.strip().split(None, 1)  # split on first space only: [date, rest]
-            if len(parts) == 2:
-                name_part = parts[1].strip()
-                priority = "C"
-                if "[" in name_part:
-                    priority = name_part.split("[")[-1].strip("] ").upper()
-                    name_part = name_part.split("[")[0].strip()
-                extra_races.append({"date": parts[0], "name": name_part, "priority": priority})
+            if len(parts) != 2:
+                continue
+            raw_date, rest = parts[0], parts[1].strip()
+            try:
+                validate_date(raw_date)
+            except ValueError:
+                return f"Error: invalid date '{raw_date}' in additional_races. Use YYYY-MM-DD."
+            priority = "C"
+            name_part = rest
+            if "[" in rest:
+                priority = rest.split("[")[-1].strip("] ").upper()
+                name_part = rest.split("[")[0].strip()
+            if priority not in ("A", "B", "C"):
+                return f"Error: invalid priority '{priority}' for race '{name_part}'. Use A, B or C."
+            extra_races.append({"date": raw_date, "name": name_part, "priority": priority})
 
     # Determine phases
     phase_list = _determine_phases(total_weeks, current_ctl, float(goal_ctl))
@@ -436,7 +441,10 @@ async def get_atp_plan(
         return f"Error fetching ATP plan: {result.get('message')}"
 
     events = result if isinstance(result, list) else []
-    notes = [e for e in events if e.get("category") == "NOTE"]
+    notes = [
+        e for e in events
+        if e.get("category") == "NOTE" and (e.get("name") or "").startswith("ATP")
+    ]
 
     if not notes:
         return (
@@ -496,7 +504,10 @@ async def get_atp_week_note(
         return f"Error fetching events: {result.get('message')}"
 
     events = result if isinstance(result, list) else []
-    notes = [e for e in events if e.get("category") == "NOTE"]
+    notes = [
+        e for e in events
+        if e.get("category") == "NOTE" and (e.get("name") or "").startswith("ATP")
+    ]
 
     if not notes:
         return (
@@ -588,7 +599,10 @@ async def get_planning_context(
 
     # ATP phase note
     sections.append("## ATP phase")
-    atp_notes = [e for e in week_list if e.get("category") == "NOTE"]
+    atp_notes = [
+        e for e in week_list
+        if e.get("category") == "NOTE" and (e.get("name") or "").startswith("ATP")
+    ]
     if atp_notes:
         for n in atp_notes:
             name = n.get("name", "")
@@ -709,6 +723,12 @@ async def add_race_event(
     priority_upper = priority.strip().upper()
     if priority_upper not in ("A", "B", "C"):
         return "Error: priority must be A, B, or C."
+
+    from datetime import datetime as _dt
+    try:
+        _dt.strptime(start_time, "%H:%M:%S")
+    except ValueError:
+        return "Error: start_time must be in HH:MM:SS format (e.g. '10:00:00')."
 
     event_data: dict[str, Any] = {
         "category": f"RACE_{priority_upper}",

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -547,7 +547,7 @@ async def get_planning_context(
     sunday = monday + timedelta(days=6)
     today = date.today()
 
-    wellness_result, week_events, races_result = await asyncio.gather(
+    _raw = await asyncio.gather(
         make_intervals_request(
             url=f"/athlete/{athlete_id_to_use}/wellness",
             api_key=api_key,
@@ -571,11 +571,16 @@ async def get_planning_context(
         ),
         return_exceptions=True,
     )
-
-    # Unwrap any exceptions returned by gather (return_exceptions=True)
-    wellness_result = wellness_result if not isinstance(wellness_result, BaseException) else []
-    week_events = week_events if not isinstance(week_events, BaseException) else []
-    races_result = races_result if not isinstance(races_result, BaseException) else []
+    _fallback: list[Any] = []
+    wellness_result: dict[str, Any] | list[dict[str, Any]] = (
+        _raw[0] if not isinstance(_raw[0], BaseException) else _fallback
+    )
+    week_events: dict[str, Any] | list[dict[str, Any]] = (
+        _raw[1] if not isinstance(_raw[1], BaseException) else _fallback
+    )
+    races_result: dict[str, Any] | list[dict[str, Any]] = (
+        _raw[2] if not isinstance(_raw[2], BaseException) else _fallback
+    )
 
     week_list = week_events if isinstance(week_events, list) else []
     sections: list[str] = [f"# Planningcontext: week {monday} – {sunday}\n"]

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -36,6 +36,7 @@ _PHASES: dict[str, dict[str, Any]] = {
         "intensity": "80% Z2, 15% sweet spot, 5% threshold.",
         "key_sessions": ["Long Z2 endurance rides", "Strength training", "Flexibility / technique"],
         "tss_factor": 0.60,
+        "recovery_factor": 0.60,
     },
     "base": {
         "label": "Base",
@@ -44,6 +45,7 @@ _PHASES: dict[str, dict[str, Any]] = {
         "intensity": "65% Z2, 25% sweet spot, 10% threshold.",
         "key_sessions": ["Long endurance rides (3–5 h)", "2× sweet spot per week", "1× threshold interval"],
         "tss_factor": 0.80,
+        "recovery_factor": 0.60,
     },
     "build": {
         "label": "Build",
@@ -52,6 +54,7 @@ _PHASES: dict[str, dict[str, Any]] = {
         "intensity": "40% Z2, 30% threshold, 30% VO2max / anaerobic.",
         "key_sessions": ["2× VO2max or threshold per week", "Long endurance ride", "Race simulation"],
         "tss_factor": 1.00,
+        "recovery_factor": 0.60,
     },
     "peak": {
         "label": "Peak",
@@ -60,6 +63,7 @@ _PHASES: dict[str, dict[str, Any]] = {
         "intensity": "50% Z2, 25% threshold, 25% VO2max — shorter intervals.",
         "key_sessions": ["Race-pace intervals", "Activation ride 2 days before race", "Rest day before race"],
         "tss_factor": 0.65,
+        "recovery_factor": 0.60,
     },
     "race": {
         "label": "Race",
@@ -68,10 +72,12 @@ _PHASES: dict[str, dict[str, Any]] = {
         "intensity": "Race + recovery rides.",
         "key_sessions": ["Activation ride the day before", "Race", "Active recovery afterwards"],
         "tss_factor": 0.50,
+        "recovery_factor": 0.60,
     },
 }
 
 _ATP_PREFIX = "ATP — "
+_TRAILING_PRIORITY_RE = re.compile(r'^(.*?)\s*\[([A-Ca-c])\]\s*$')
 
 
 def _is_atp_note(e: object) -> bool:
@@ -138,8 +144,10 @@ def _determine_phases(total_weeks: int, current_ctl: float, goal_ctl: float) -> 
     phases: list[tuple[str, int]] = []
     if prep_wks >= 2:
         phases.append(("preparation", prep_wks))
-    phases.append(("base", base_wks))
-    phases.append(("build", build_wks))
+    if base_wks > 0:
+        phases.append(("base", base_wks))
+    if build_wks > 0:
+        phases.append(("build", build_wks))
     return phases + tail
 
 
@@ -187,12 +195,14 @@ def _weeks_in(start: date, end: date) -> int:
 
 
 def _week_tss(phase: str, goal_tss: int, week: int, cycle: int, load_week_idx: dict[int, int]) -> str:
-    factor = _PHASES[phase]["tss_factor"]
+    p = _PHASES[phase]
+    factor = p["tss_factor"]
     if week % cycle == 0:
-        return f"~{round(goal_tss * factor * 0.60 / 50) * 50} TSS  ← recovery week"
+        tss = max(50, round(goal_tss * factor * p["recovery_factor"] / 50) * 50)
+        return f"~{tss} TSS  ← recovery week"
     idx = load_week_idx.get(week, 0)
     prog = 0.85 + 0.15 * (idx / max(len(load_week_idx) - 1, 1))
-    tss = round(goal_tss * factor * prog / 50) * 50
+    tss = max(50, round(goal_tss * factor * prog / 50) * 50)
     return f"~{tss} TSS"
 
 
@@ -303,7 +313,7 @@ async def create_atp_plan(
         return "Error: recovery_cycle must be 3 or 4."
 
     today = date.today()
-    if race_dt <= today:
+    if race_dt < today:
         return f"Error: race_date {race_date} is in the past. Provide a future date."
 
     today_monday = _monday_of(today)
@@ -335,7 +345,6 @@ async def create_atp_plan(
     # Parse additional races
     extra_races: list[dict] = []
     if additional_races:
-        _trailing_priority = re.compile(r'^(.*?)\s*\[([A-Ca-c])\]\s*$')
         for line in additional_races.strip().splitlines():
             if not line.strip():
                 continue
@@ -347,7 +356,7 @@ async def create_atp_plan(
                 validate_date(raw_date)
             except ValueError:
                 return f"Error: invalid date '{raw_date}' in additional_races. Use YYYY-MM-DD."
-            m = _trailing_priority.match(rest)
+            m = _TRAILING_PRIORITY_RE.match(rest)
             if m:
                 name_part, priority = m.group(1).strip(), m.group(2).upper()
             else:
@@ -362,9 +371,8 @@ async def create_atp_plan(
         params={"oldest": today_monday.isoformat(), "newest": plan_end.isoformat()},
     )
     old_ids = [
-        ev_id for ev in (existing if isinstance(existing, list) else [])
-        if _is_atp_note(ev) and isinstance(ev, dict)
-        for ev_id in (ev.get("id"),) if ev_id
+        ev.get("id") for ev in (existing if isinstance(existing, list) else [])
+        if _is_atp_note(ev) and isinstance(ev, dict) and ev.get("id")
     ]
 
     _sem = asyncio.Semaphore(3)
@@ -441,14 +449,20 @@ async def create_atp_plan(
     ]
     failed = [r for r in post_results if isinstance(r, Exception) or (isinstance(r, dict) and "error" in r)]
     if failed:
-        await asyncio.gather(*(_delete(ev_id) for ev_id in created_ids))
+        await asyncio.gather(*(_delete(ev_id) for ev_id in created_ids), return_exceptions=True)
         f = failed[0]
         err_msg = (f.get("message") or f.get("error") or str(f)) if isinstance(f, dict) else str(f)
         return f"Error creating ATP plan (rolled back, existing plan preserved): {err_msg}"
 
     # All POSTs succeeded — now safe to remove the old notes
     if old_ids:
-        await asyncio.gather(*(_delete(ev_id) for ev_id in old_ids))
+        delete_results = await asyncio.gather(*(_delete(ev_id) for ev_id in old_ids), return_exceptions=True)
+        delete_failures = [r for r in delete_results if isinstance(r, Exception)]
+        if delete_failures:
+            return (
+                f"ATP plan created but {len(delete_failures)} old note(s) could not be deleted "
+                f"(may cause duplicates): {delete_failures[0]}"
+            )
 
     posted_lines: list[str] = []
     for (ph, _), _ in zip(phase_events, post_results):
@@ -514,7 +528,7 @@ async def get_atp_plan(
     )
 
     if isinstance(result, dict) and "error" in result:
-        return f"Error fetching ATP plan: {result.get('message')}"
+        return f"Error fetching ATP plan: {result.get('message') or result.get('error') or str(result)}"
 
     events = result if isinstance(result, list) else []
     notes = [
@@ -851,7 +865,7 @@ async def add_race_event(
     )
 
     if isinstance(result, dict) and "error" in result:
-        return f"Error adding race: {result.get('message')}"
+        return f"Error adding race: {result.get('message') or result.get('error') or str(result)}"
 
     if not isinstance(result, dict):
         return f"Unexpected response adding race: {result}"

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -9,6 +9,7 @@ athlete's current fitness level:
 - get_atp_plan     reads all phase notes from the calendar.
 - get_atp_week_note  returns the phase note covering a specific week.
 - get_planning_context  returns fitness + ATP note + events for weekly planning.
+- add_race_event   adds a race event with priority A, B, or C.
 """
 
 import asyncio
@@ -28,43 +29,43 @@ config = get_config()
 
 _PHASES: dict[str, dict[str, Any]] = {
     "preparation": {
-        "label": "Voorbereiding",
+        "label": "Preparation",
         "color": "green",
-        "focus": "Algemene conditie opbouwen. Aerobe basis leggen, kracht en techniek.",
-        "intensity": "80% Z2, 15% sweetspot, 5% drempel.",
-        "key_sessions": ["Lange Z2 duurritten", "Krachttraining", "Soepelheid / techniek"],
+        "focus": "Build general fitness. Establish aerobic base, strength and technique.",
+        "intensity": "80% Z2, 15% sweet spot, 5% threshold.",
+        "key_sessions": ["Long Z2 endurance rides", "Strength training", "Flexibility / technique"],
         "tss_factor": 0.60,
     },
     "base": {
-        "label": "Basis",
+        "label": "Base",
         "color": "blue",
-        "focus": "Aerobe motor versterken. Hoog volume Z2, sweetspot, drempel introductie.",
-        "intensity": "65% Z2, 25% sweetspot, 10% drempel.",
-        "key_sessions": ["Lange duurritten (3–5 uur)", "2× sweetspot per week", "1× drempelinterval"],
+        "focus": "Strengthen the aerobic engine. High Z2 volume, sweet spot, threshold introduction.",
+        "intensity": "65% Z2, 25% sweet spot, 10% threshold.",
+        "key_sessions": ["Long endurance rides (3–5 h)", "2× sweet spot per week", "1× threshold interval"],
         "tss_factor": 0.80,
     },
     "build": {
-        "label": "Opbouw",
+        "label": "Build",
         "color": "orange",
-        "focus": "Wedstrijdspecifieke kwaliteiten. Drempel, VO2max en anaerobe capaciteit uitbouwen.",
-        "intensity": "40% Z2, 30% drempel, 30% VO2max / anaeroob.",
-        "key_sessions": ["2× VO2max of drempel per week", "Lange duurrit", "Wedstrijdsimulatie"],
+        "focus": "Race-specific qualities. Develop threshold, VO2max and anaerobic capacity.",
+        "intensity": "40% Z2, 30% threshold, 30% VO2max / anaerobic.",
+        "key_sessions": ["2× VO2max or threshold per week", "Long endurance ride", "Race simulation"],
         "tss_factor": 1.00,
     },
     "peak": {
-        "label": "Piek",
+        "label": "Peak",
         "color": "red",
-        "focus": "Scherp worden voor de koers. Volume daalt, intensiteit blijft hoog. Tapering.",
-        "intensity": "50% Z2, 25% drempel, 25% VO2max — kortere intervallen.",
-        "key_sessions": ["Race-pace intervallen", "Activatierit 2 dagen voor koers", "Rustdag voor koers"],
+        "focus": "Get sharp for the race. Volume drops, intensity stays high. Taper.",
+        "intensity": "50% Z2, 25% threshold, 25% VO2max — shorter intervals.",
+        "key_sessions": ["Race-pace intervals", "Activation ride 2 days before race", "Rest day before race"],
         "tss_factor": 0.65,
     },
     "race": {
-        "label": "Koers",
+        "label": "Race",
         "color": "red",
-        "focus": "Presteren op de A-koers. Minimale training, volle focus op wedstrijd en herstel.",
-        "intensity": "Wedstrijd + herstelritten.",
-        "key_sessions": ["Activatierit daags voor koers", "Wedstrijd", "Actief herstel erna"],
+        "focus": "Perform at the A-race. Minimal training, full focus on racing and recovery.",
+        "intensity": "Race + recovery rides.",
+        "key_sessions": ["Activation ride the day before", "Race", "Active recovery afterwards"],
         "tss_factor": 0.50,
     },
 }
@@ -78,8 +79,8 @@ def _determine_phases(total_weeks: int, current_ctl: float, goal_ctl: float) -> 
     """Return ordered (phase_name, weeks) based on available weeks and CTL gap.
 
     Uses the ratio current_ctl / goal_ctl so thresholds scale with the event:
-    - UCI belofte targeting CTL 110 with current 70 → big gap → needs base
-    - Toertocht finisher targeting CTL 60 with current 50 → small gap → straight to build
+    - UCI u23 rider targeting CTL 110 with current 70 → big gap → needs base
+    - Gran fondo finisher targeting CTL 60 with current 50 → small gap → straight to build
     """
     peak_wks = min(2, max(1, total_weeks // 7))
     race_wks = 1
@@ -129,20 +130,20 @@ def _reason_for_phases(current_ctl: float, goal_ctl: float, total_weeks: int) ->
     ratio = current_ctl / max(goal_ctl, 1.0)
     gap = round(goal_ctl - current_ctl)
     if total_weeks <= 5:
-        return f"Slechts {total_weeks} weken beschikbaar — direct naar piek-fase."
+        return f"Only {total_weeks} weeks available — going straight to peak phase."
     if ratio >= 0.90:
         return (
-            f"CTL {round(current_ctl)} is al dicht bij doel-CTL {goal_ctl} "
-            f"(gap: {gap}) — direct naar opbouwfase."
+            f"CTL {round(current_ctl)} is close to goal CTL {goal_ctl} "
+            f"(gap: {gap}) — going straight to build phase."
         )
     if ratio >= 0.70:
         return (
-            f"CTL {round(current_ctl)} is {gap} punten onder doel-CTL {goal_ctl} "
-            f"({round(ratio * 100)}%) — korte basisblok gevolgd door opbouwfase."
+            f"CTL {round(current_ctl)} is {gap} points below goal CTL {goal_ctl} "
+            f"({round(ratio * 100)}%) — short base block followed by build phase."
         )
     return (
-        f"CTL {round(current_ctl)} is {gap} punten onder doel-CTL {goal_ctl} "
-        f"({round(ratio * 100)}%) — voorbereiding en basisblok nodig voor opbouw."
+        f"CTL {round(current_ctl)} is {gap} points below goal CTL {goal_ctl} "
+        f"({round(ratio * 100)}%) — preparation and base block needed before build."
     )
 
 
@@ -165,7 +166,7 @@ def _recovery_week_numbers(total_weeks: int, cycle: int) -> list[int]:
 def _week_tss(phase: str, goal_tss: int, week: int, total_weeks: int, cycle: int) -> str:
     factor = _PHASES[phase]["tss_factor"]
     if week % cycle == 0:
-        return f"~{round(goal_tss * factor * 0.60 / 50) * 50} TSS  ← herstelweek"
+        return f"~{round(goal_tss * factor * 0.60 / 50) * 50} TSS  ← recovery week"
     load_weeks = [w for w in range(1, total_weeks + 1) if w % cycle != 0]
     idx = load_weeks.index(week) if week in load_weeks else 0
     prog = 0.85 + 0.15 * (idx / max(len(load_weeks) - 1, 1))
@@ -189,26 +190,26 @@ def _build_phase_note(
     total_wks = _weeks_in(start, end)
 
     lines = [
-        f"Fase {phase_num}/{total_phases}: {p['label']}",
-        f"Periode: {start} – {end} ({total_wks} weken)",
-        f"Doel: {p['focus']}",
-        f"Intensiteit: {p['intensity']}",
+        f"Phase {phase_num}/{total_phases}: {p['label']}",
+        f"Period: {start} – {end} ({total_wks} weeks)",
+        f"Goal: {p['focus']}",
+        f"Intensity: {p['intensity']}",
         "",
-        "Hoofdtrainingen per week:",
+        "Key sessions per week:",
         *[f"  • {s}" for s in p["key_sessions"]],
         "",
-        "Weekschema:",
+        "Weekly schedule:",
     ]
     for w in range(1, total_wks + 1):
         w_start = start + timedelta(weeks=w - 1)
         w_end = min(w_start + timedelta(days=6), end)
         lines.append(f"  Week {w} ({w_start} – {w_end}): {_week_tss(phase, goal_tss, w, total_wks, cycle)}")
 
-    lines += ["", f"A-koers: {race_name} ({race_date})"]
+    lines += ["", f"A-race: {race_name} ({race_date})"]
     if phase_races:
-        lines.append("Wedstrijden in deze fase:")
+        lines.append("Races in this phase:")
         for r in phase_races:
-            lines.append(f"  • {r['date']} — {r['name']} [{r.get('priority','C')}]")
+            lines.append(f"  • {r['date']} — {r['name']} [{r.get('priority', 'C')}]")
 
     return "\n".join(lines)
 
@@ -235,16 +236,16 @@ async def create_atp_plan(
     between current and goal CTL, the more base-building phases are added.
 
     Phase selection (based on current CTL as % of goal CTL):
-    - ≥ 90% of goal: already close → Build → Peak → Race
+    - >= 90% of goal: already close → Build → Peak → Race
     - 70–90% of goal: moderate gap → Base → Build → Peak → Race
-    - < 70% of goal: large gap  → Preparation → Base → Build → Peak → Race
+    - < 70% of goal:  large gap   → Preparation → Base → Build → Peak → Race
 
     goal_ctl reference values (CTL needed at race day):
-    - Finish a sportive / gran fondo:        50–70
-    - Club-level amateur racer:              70–90
-    - Competitive amateur / cat. 3–4:        90–110
-    - Semi-pro / UCI belofte:               100–130
-    - Pro continental / WorldTour:          130+
+    - Finish a sportive / gran fondo:       50–70
+    - Club-level amateur racer:             70–90
+    - Competitive amateur / cat. 3–4:       90–110
+    - Semi-pro / UCI U23:                  100–130
+    - Pro continental / WorldTour:         130+
 
     Each phase is posted as a NOTE event spanning its full date range on the
     Intervals.icu calendar. The note contains training focus, intensity split,
@@ -252,13 +253,13 @@ async def create_atp_plan(
 
     Args:
         race_date: Date of the A-race in YYYY-MM-DD format
-        race_name: Name of the A-race (e.g. "Ronde van Vlaanderen")
+        race_name: Name of the A-race (e.g. "Tour of Flanders")
         goal_ctl: Target CTL (fitness) needed at race day — see reference above
         recovery_cycle: Recovery week every N weeks — 3 for older/less experienced
                         athletes, 4 for younger/experienced athletes (default 4)
         additional_races: Optional B/C races, one per line as
                           "YYYY-MM-DD Name [A/B/C]"
-                          e.g. "2026-03-21 Dwars door V. C"
+                          e.g. "2026-03-21 Dwars door Vlaanderen [C]"
         athlete_id: The Intervals.icu athlete ID (optional)
         api_key: The Intervals.icu API key (optional)
     """
@@ -294,12 +295,12 @@ async def create_atp_plan(
     )
 
     current_ctl: float = 30.0  # fallback if no data
-    ctl_source = "onbekend (geen wellness-data)"
+    ctl_source = "unknown (no wellness data)"
     if isinstance(wellness_result, list) and wellness_result:
         for entry in reversed(wellness_result):
             if isinstance(entry, dict) and entry.get("ctl") is not None:
                 current_ctl = float(entry["ctl"])
-                ctl_source = f"{round(current_ctl, 1)} (uit wellness {entry.get('id', '')})"
+                ctl_source = f"{round(current_ctl, 1)} (from wellness {entry.get('id', '')})"
                 break
 
     # Weekly TSS in peak build weeks ≈ goal_ctl × 7
@@ -309,7 +310,7 @@ async def create_atp_plan(
     extra_races: list[dict] = []
     if additional_races:
         for line in additional_races.strip().splitlines():
-            parts = line.strip().split(None, 1)   # split on first space only: [date, rest]
+            parts = line.strip().split(None, 1)  # split on first space only: [date, rest]
             if len(parts) == 2:
                 name_part = parts[1].strip()
                 priority = "C"
@@ -375,15 +376,15 @@ async def create_atp_plan(
 
     phase_names = " → ".join(_PHASES[ph["name"]]["label"] for ph in phase_ranges)
     summary = [
-        f"ATP aangemaakt voor {race_name} ({race_date})",
-        f"Periode: {today_monday} – {race_monday + timedelta(days=6)} ({total_weeks} weken)",
-        f"Huidige CTL: {ctl_source}",
-        f"Doel-CTL: {goal_ctl}  →  TSS-doel piekweek: ~{goal_weekly_tss}",
-        f"Reden fasekeuze: {reason}",
-        f"Fasen: {phase_names}",
-        f"Herstelcyclus: elke {recovery_cycle} weken",
+        f"ATP created for {race_name} ({race_date})",
+        f"Period: {today_monday} – {race_monday + timedelta(days=6)} ({total_weeks} weeks)",
+        f"Current CTL: {ctl_source}",
+        f"Goal CTL: {goal_ctl}  →  Peak week TSS target: ~{goal_weekly_tss}",
+        f"Phase selection: {reason}",
+        f"Phases: {phase_names}",
+        f"Recovery cycle: every {recovery_cycle} weeks",
         "",
-        "Gepost op kalender:",
+        "Posted to calendar:",
     ] + posted_lines
 
     return "\n".join(summary)
@@ -439,11 +440,11 @@ async def get_atp_plan(
 
     if not notes:
         return (
-            f"Geen ATP-notities gevonden tussen {start_date} en {end_date}. "
-            "Gebruik create_atp_plan om een plan aan te maken."
+            f"No ATP notes found between {start_date} and {end_date}. "
+            "Use create_atp_plan to create a plan."
         )
 
-    lines = [f"ATP-overzicht ({start_date} – {end_date})\n"]
+    lines = [f"ATP overview ({start_date} – {end_date})\n"]
     for note in notes:
         name = note.get("name", "")
         s = (note.get("start_date_local") or "")[:10]
@@ -499,11 +500,11 @@ async def get_atp_week_note(
 
     if not notes:
         return (
-            f"Geen ATP-notitie gevonden voor week {monday} – {sunday}. "
-            "Gebruik create_atp_plan om het seizoen te structureren."
+            f"No ATP note found for week {monday} – {sunday}. "
+            "Use create_atp_plan to structure the season."
         )
 
-    lines = [f"ATP voor week {monday} – {sunday}:\n"]
+    lines = [f"ATP for week {monday} – {sunday}:\n"]
     for note in notes:
         name = note.get("name", "")
         desc = note.get("description", "")
@@ -583,10 +584,10 @@ async def get_planning_context(
     )
 
     week_list = week_events if isinstance(week_events, list) else []
-    sections: list[str] = [f"# Planningcontext: week {monday} – {sunday}\n"]
+    sections: list[str] = [f"# Planning context: week {monday} – {sunday}\n"]
 
     # ATP phase note
-    sections.append("## ATP-fase")
+    sections.append("## ATP phase")
     atp_notes = [e for e in week_list if e.get("category") == "NOTE"]
     if atp_notes:
         for n in atp_notes:
@@ -595,27 +596,30 @@ async def get_planning_context(
             sections.append(f"**{name}**\n{desc}" if name else desc)
     else:
         sections.append(
-            "Geen ATP-notitie voor deze week. Gebruik create_atp_plan om het seizoen te structureren."
+            "No ATP note for this week. Use create_atp_plan to structure the season."
         )
 
     # Fitness
-    sections.append("\n## Conditie (afgelopen 14 dagen)")
+    sections.append("\n## Current fitness (last 14 days)")
     if isinstance(wellness_result, list) and wellness_result:
-        latest = next((e for e in reversed(wellness_result) if isinstance(e, dict) and e.get("ctl") is not None), None)
+        latest = next(
+            (e for e in reversed(wellness_result) if isinstance(e, dict) and e.get("ctl") is not None),
+            None,
+        )
         if latest:
             ctl = latest.get("ctl")
             atl = latest.get("atl")
             tsb = round(ctl - atl, 1) if ctl is not None and atl is not None else None
             form = ""
             if tsb is not None:
-                form = " (uitgerust)" if tsb > 10 else (" (vermoeid)" if tsb < -10 else " (neutraal)")
+                form = " (fresh)" if tsb > 10 else (" (fatigued)" if tsb < -10 else " (neutral)")
             lines = []
             if ctl is not None:
                 lines.append(f"CTL (fitness): {round(ctl, 1)}")
             if atl is not None:
-                lines.append(f"ATL (vermoeidheid): {round(atl, 1)}")
+                lines.append(f"ATL (fatigue): {round(atl, 1)}")
             if tsb is not None:
-                lines.append(f"TSB (vorm): {tsb}{form}")
+                lines.append(f"TSB (form): {tsb}{form}")
             hrv = latest.get("hrv")
             if hrv is not None:
                 lines.append(f"HRV: {hrv}")
@@ -624,12 +628,12 @@ async def get_planning_context(
                 lines.append(f"Ramp rate: {round(ramp, 1)} CTL/week")
             sections.append("\n".join(lines))
         else:
-            sections.append("Geen CTL/ATL beschikbaar.")
+            sections.append("No CTL/ATL data available.")
     else:
-        sections.append("Geen wellness-data beschikbaar.")
+        sections.append("No wellness data available.")
 
     # Planned workouts
-    sections.append("\n## Geplande workouts deze week")
+    sections.append("\n## Planned workouts this week")
     workouts = [e for e in week_list if e.get("category") == "WORKOUT"]
     if workouts:
         for w in workouts:
@@ -640,22 +644,22 @@ async def get_planning_context(
             dur = f" ({int(mt) // 60} min)" if mt else ""
             sections.append(f"- {d} [{wtype}] {name}{dur}")
     else:
-        sections.append("Nog geen workouts ingepland.")
+        sections.append("No workouts scheduled yet.")
 
     # Upcoming races
-    sections.append("\n## Komende wedstrijden (120 dagen)")
+    sections.append("\n## Upcoming races (120 days)")
     if isinstance(races_result, list) and races_result:
         races = [e for e in races_result if e.get("category") in ("RACE_A", "RACE_B", "RACE_C")]
         if races:
             for r in races:
                 d = (r.get("start_date_local") or "")[:10]
-                name = r.get("name", "wedstrijd")
+                name = r.get("name", "race")
                 cat = r.get("category", "")
                 sections.append(f"- {d}: {name} [{cat}]")
         else:
-            sections.append("Geen wedstrijden gepland.")
+            sections.append("No races scheduled.")
     else:
-        sections.append("Geen wedstrijden gepland.")
+        sections.append("No races scheduled.")
 
     return "\n".join(sections)
 
@@ -682,7 +686,7 @@ async def add_race_event(
     - C: training race — treat as a hard training day
 
     Args:
-        name: Name of the race (e.g. "Ronde van Vlaanderen")
+        name: Name of the race (e.g. "Tour of Flanders")
         race_date: Date of the race in YYYY-MM-DD format
         priority: Race priority — A, B, or C (default A)
         start_time: Start time in HH:MM:SS format (default 10:00:00)
@@ -732,4 +736,4 @@ async def add_race_event(
 
     event_id = result.get("id") if isinstance(result, dict) else None
     id_str = f" (id: {event_id})" if event_id else ""
-    return f"Race '{name}' aangemaakt op {race_date} [RACE_{priority_upper}]{id_str}."
+    return f"Race '{name}' added on {race_date} [RACE_{priority_upper}]{id_str}."

--- a/src/intervals_mcp_server/tools/planning.py
+++ b/src/intervals_mcp_server/tools/planning.py
@@ -354,13 +354,19 @@ async def create_atp_plan(
                 name_part, priority = rest, "C"
             extra_races.append({"date": raw_date, "name": name_part, "priority": priority})
 
-    # Delete any existing ATP notes in the plan window to avoid duplicates
+    # Fetch existing ATP notes now; delete them only after new ones are created
     plan_end = _monday_of(race_dt) + timedelta(days=6)
     existing = await make_intervals_request(
         url=f"/athlete/{athlete_id_to_use}/events",
         api_key=api_key,
         params={"oldest": today_monday.isoformat(), "newest": plan_end.isoformat()},
     )
+    old_ids = [
+        ev_id for ev in (existing if isinstance(existing, list) else [])
+        if _is_atp_note(ev) and isinstance(ev, dict)
+        for ev_id in (ev.get("id"),) if ev_id
+    ]
+
     _sem = asyncio.Semaphore(3)
 
     async def _delete(ev_id: str) -> None:
@@ -370,13 +376,6 @@ async def create_atp_plan(
                 api_key=api_key,
                 method="DELETE",
             )
-
-    to_delete = [
-        ev["id"] for ev in (existing if isinstance(existing, list) else [])
-        if _is_atp_note(ev) and isinstance(ev, dict) and ev.get("id")
-    ]
-    if to_delete:
-        await asyncio.gather(*(_delete(ev_id) for ev_id in to_delete))
 
     # Determine phases
     phase_list = _determine_phases(total_weeks, current_ctl, float(goal_ctl))
@@ -435,7 +434,7 @@ async def create_atp_plan(
         return_exceptions=True,
     )
 
-    # Rollback any created events if a failure occurred
+    # On any failure: rollback newly created events (old notes are still intact)
     created_ids = [
         r["id"] for r in post_results
         if isinstance(r, dict) and "id" in r and "error" not in r
@@ -445,7 +444,11 @@ async def create_atp_plan(
         await asyncio.gather(*(_delete(ev_id) for ev_id in created_ids))
         f = failed[0]
         err_msg = (f.get("message") or f.get("error") or str(f)) if isinstance(f, dict) else str(f)
-        return f"Error creating ATP plan (all changes rolled back): {err_msg}"
+        return f"Error creating ATP plan (rolled back, existing plan preserved): {err_msg}"
+
+    # All POSTs succeeded — now safe to remove the old notes
+    if old_ids:
+        await asyncio.gather(*(_delete(ev_id) for ev_id in old_ids))
 
     posted_lines: list[str] = []
     for (ph, _), _ in zip(phase_events, post_results):
@@ -663,19 +666,28 @@ async def get_planning_context(
     _fallback: list[Any] = []
     _api_warnings: list[str] = []
     _labels = ("wellness", "week events", "upcoming races")
+
+    def _is_failed(item: Any) -> bool:
+        return isinstance(item, Exception) or (isinstance(item, dict) and "error" in item)
+
+    def _warn_msg(item: Any) -> str:
+        if isinstance(item, dict):
+            return item.get("message") or item.get("error") or str(item)
+        return str(item)
+
     for _label, _raw_item in zip(_labels, _raw):
         if isinstance(_raw_item, asyncio.CancelledError):
             raise _raw_item
-        if isinstance(_raw_item, Exception):
-            _api_warnings.append(f"  • {_label}: {_raw_item}")
+        if _is_failed(_raw_item):
+            _api_warnings.append(f"  • {_label}: {_warn_msg(_raw_item)}")
     wellness_result: dict[str, Any] | list[dict[str, Any]] = (
-        _raw[0] if not isinstance(_raw[0], Exception) else _fallback
+        _raw[0] if not _is_failed(_raw[0]) else _fallback
     )
     week_events: dict[str, Any] | list[dict[str, Any]] = (
-        _raw[1] if not isinstance(_raw[1], Exception) else _fallback
+        _raw[1] if not _is_failed(_raw[1]) else _fallback
     )
     races_result: dict[str, Any] | list[dict[str, Any]] = (
-        _raw[2] if not isinstance(_raw[2], Exception) else _fallback
+        _raw[2] if not _is_failed(_raw[2]) else _fallback
     )
 
     week_list = week_events if isinstance(week_events, list) else []

--- a/src/intervals_mcp_server/tools/power_curves.py
+++ b/src/intervals_mcp_server/tools/power_curves.py
@@ -11,7 +11,7 @@ from typing import Any
 from intervals_mcp_server.api.client import make_intervals_request
 from intervals_mcp_server.config import get_config
 from intervals_mcp_server.utils.formatting import format_power_curves
-from intervals_mcp_server.utils.validation import resolve_activity_type, resolve_athlete_id
+from intervals_mcp_server.utils.validation import resolve_athlete_id
 
 # Import mcp instance from shared module for tool registration
 from intervals_mcp_server.mcp_instance import mcp  # noqa: F401

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,144 @@
+"""
+Unit tests for event helpers in intervals_mcp_server.tools.events.
+
+Covers:
+- format_strength_description: bullet-point formatting for WeightTraining
+- _prepare_event_data: description_override behaviour
+"""
+
+import os
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+os.environ.setdefault("API_KEY", "test")
+os.environ.setdefault("ATHLETE_ID", "i1")
+
+from intervals_mcp_server.tools.events import format_strength_description, _prepare_event_data
+
+
+BLOCKS_A = [
+    {
+        "name": "Blok A — Core/onderrug",
+        "exercises": [
+            "Dead bug 3x10/kant — rug plat, been en arm tegelijk uitstrekken",
+            "Bird dog 3x10/kant — op handen en knieën, heupen stabiel",
+        ],
+    }
+]
+
+BLOCKS_AB = [
+    {
+        "name": "Blok A — Core/onderrug",
+        "exercises": ["Dead bug 3x10/kant", "Bird dog 3x10/kant"],
+    },
+    {
+        "name": "Blok B — Upper body",
+        "exercises": ["Dumbbell row 3x10/kant", "Shoulder press 3x10"],
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# format_strength_description
+# ---------------------------------------------------------------------------
+
+class TestFormatStrengthDescription:
+    def test_title_is_first_line(self):
+        result = format_strength_description("Core en onderrug. ~25 min.", BLOCKS_A)
+        assert result.split("\n")[0] == "Core en onderrug. ~25 min."
+
+    def test_block_name_present(self):
+        result = format_strength_description("Title", BLOCKS_A)
+        assert "Blok A — Core/onderrug" in result
+
+    def test_exercises_prefixed_with_dash(self):
+        result = format_strength_description("Title", BLOCKS_A)
+        assert "- Dead bug 3x10/kant — rug plat, been en arm tegelijk uitstrekken" in result
+        assert "- Bird dog 3x10/kant — op handen en knieën, heupen stabiel" in result
+
+    def test_no_trailing_newline(self):
+        result = format_strength_description("Title", BLOCKS_A)
+        assert not result.endswith("\n")
+
+    def test_multiple_blocks_all_present(self):
+        result = format_strength_description("Title", BLOCKS_AB)
+        assert "Blok A — Core/onderrug" in result
+        assert "Blok B — Upper body" in result
+        assert "- Dead bug 3x10/kant" in result
+        assert "- Dumbbell row 3x10/kant" in result
+
+    def test_blank_line_between_title_and_first_block(self):
+        result = format_strength_description("Title", BLOCKS_A)
+        lines = result.split("\n")
+        assert lines[1] == ""  # blank separator after title
+
+    def test_empty_blocks_returns_title_only(self):
+        result = format_strength_description("Title", [])
+        assert result == "Title"
+
+    def test_output_matches_expected_format(self):
+        result = format_strength_description("Core en onderrug. ~25 min.", BLOCKS_A)
+        expected = (
+            "Core en onderrug. ~25 min.\n"
+            "\n"
+            "Blok A — Core/onderrug\n"
+            "- Dead bug 3x10/kant — rug plat, been en arm tegelijk uitstrekken\n"
+            "- Bird dog 3x10/kant — op handen en knieën, heupen stabiel"
+        )
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# _prepare_event_data — description_override
+# ---------------------------------------------------------------------------
+
+class TestPrepareEventDataDescriptionOverride:
+    def test_override_is_used_when_provided(self):
+        data = _prepare_event_data(
+            name="Core sessie",
+            workout_type="WeightTraining",
+            start_date="2026-06-29",
+            workout_doc=None,
+            moving_time=None,
+            distance=None,
+            description_override="Custom description",
+        )
+        assert data["description"] == "Custom description"
+
+    def test_no_override_and_no_workout_doc_gives_none(self):
+        data = _prepare_event_data(
+            name="Core sessie",
+            workout_type="WeightTraining",
+            start_date="2026-06-29",
+            workout_doc=None,
+            moving_time=None,
+            distance=None,
+        )
+        assert data["description"] is None
+
+    def test_ride_without_override_unchanged(self):
+        data = _prepare_event_data(
+            name="Easy Ride",
+            workout_type="Ride",
+            start_date="2026-06-29",
+            workout_doc=None,
+            moving_time=3600,
+            distance=None,
+        )
+        assert data["description"] is None
+        assert data["moving_time"] == 3600
+
+    def test_override_takes_precedence_over_workout_doc(self):
+        from intervals_mcp_server.utils.types import WorkoutDoc
+        doc = WorkoutDoc(description="doc desc", steps=[])
+        data = _prepare_event_data(
+            name="Sessie",
+            workout_type="WeightTraining",
+            start_date="2026-06-29",
+            workout_doc=doc,
+            moving_time=None,
+            distance=None,
+            description_override="override wins",
+        )
+        assert data["description"] == "override wins"

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -22,8 +22,6 @@ from intervals_mcp_server.tools.planning import (
     _basis_decision_note,
     _BASIS_20MIN_THRESHOLD,
     _BASIS_60MIN_THRESHOLD,
-    _BASE_SKIP_RATIO,
-    _BASE_SHORT_RATIO,
 )
 
 
@@ -152,74 +150,66 @@ import pytest
 
 
 class TestDeterminePhasesBasisPresent:
-    """basis_present=True: three-tier Base selection."""
+    """basis_present=True: powercurve is leading — always skip Base, ratio irrelevant."""
 
-    def test_ratio_above_skip_threshold_no_base(self):
-        # ratio >= _BASE_SKIP_RATIO (0.70) → skip Base entirely
+    def test_high_ratio_no_base(self):
         phases = _determine_phases(20, current_ctl=80, goal_ctl=100, basis_present=True)
         names = [p for p, _ in phases]
         assert "base" not in names
         assert "build" in names
 
-    def test_ratio_exactly_at_skip_threshold_no_base(self):
-        # ratio == 0.70 exactly → still skip Base
-        phases = _determine_phases(20, current_ctl=70, goal_ctl=100, basis_present=True)
-        names = [p for p, _ in phases]
-        assert "base" not in names
-
-    def test_ratio_in_short_base_range_base_is_two_weeks(self):
-        # _BASE_SHORT_RATIO (0.50) <= ratio < _BASE_SKIP_RATIO (0.70) → 2-week Base
+    def test_moderate_ratio_no_base(self):
+        # Previously produced a 2-week Base; now always skips
         phases = _determine_phases(20, current_ctl=60, goal_ctl=100, basis_present=True)
-        names = [p for p, _ in phases]
-        assert "base" in names
-        base_wks = next(w for p, w in phases if p == "base")
-        assert base_wks == 2
+        assert "base" not in [p for p, _ in phases]
 
-    def test_ratio_exactly_at_short_base_threshold(self):
-        # ratio == 0.50 → short Base (2 wk), not full
-        phases = _determine_phases(20, current_ctl=50, goal_ctl=100, basis_present=True)
-        base_wks = next(w for p, w in phases if p == "base")
-        assert base_wks == 2
-
-    def test_ratio_below_short_base_threshold_full_base(self):
-        # ratio < _BASE_SHORT_RATIO (0.50) → full Base (>= 3 wk), no Preparation
+    def test_low_ratio_no_base(self):
+        # Previously produced a full Base; now always skips
         phases = _determine_phases(20, current_ctl=40, goal_ctl=120, basis_present=True)
         names = [p for p, _ in phases]
-        assert "base" in names
+        assert "base" not in names
         assert "preparation" not in names
-        base_wks = next(w for p, w in phases if p == "base")
-        assert base_wks >= 3
 
-    def test_basis_present_never_adds_preparation(self):
-        # Even with very low ratio, basis_present should never produce Preparation
-        phases = _determine_phases(30, current_ctl=30, goal_ctl=120, basis_present=True)
+    def test_very_low_ratio_no_base_no_preparation(self):
+        phases = _determine_phases(30, current_ctl=25, goal_ctl=120, basis_present=True)
         names = [p for p, _ in phases]
+        assert "base" not in names
         assert "preparation" not in names
+        assert "build" in names
 
 
 class TestDeterminePhasesBasisAbsent:
-    """basis_present=False: force Base even when CTL ratio is high."""
+    """basis_present=False: same CTL-gap logic as None (ratio decides)."""
 
-    def test_basis_absent_high_ratio_adds_base(self):
-        # ratio >= 0.90 but no recent riding → should add Base
+    def test_basis_absent_high_ratio_straight_to_build(self):
+        # ratio >= 0.90 → Build only (same as basis_present=None)
         phases = _determine_phases(20, current_ctl=95, goal_ctl=100, basis_present=False)
         names = [p for p, _ in phases]
-        assert "base" in names
+        assert "base" not in names
+        assert "build" in names
 
     def test_basis_absent_moderate_ratio_adds_base(self):
-        # ratio 70–90% + basis absent → Base + Build
+        # ratio 70–90% → Base + Build
         phases = _determine_phases(20, current_ctl=75, goal_ctl=100, basis_present=False)
         names = [p for p, _ in phases]
         assert "base" in names
         assert "build" in names
 
     def test_basis_absent_low_ratio_full_plan(self):
-        # ratio < 0.70 + basis absent → Prep + Base + Build
+        # ratio < 0.70 → Prep + Base + Build
         phases = _determine_phases(30, current_ctl=40, goal_ctl=120, basis_present=False)
         names = [p for p, _ in phases]
         assert "preparation" in names
         assert "base" in names
         assert "build" in names
+
+    def test_basis_absent_identical_to_none(self):
+        """False and None produce the same phases (both use ratio-only logic)."""
+        for ctl, goal in [(95, 100), (75, 100), (40, 120)]:
+            assert (
+                _determine_phases(20, float(ctl), float(goal), basis_present=False)
+                == _determine_phases(20, float(ctl), float(goal), basis_present=None)
+            )
 
 
 class TestDeterminePhasesBasisNone:
@@ -283,29 +273,31 @@ class TestDeterminePhasesEdgeCases:
 # ---------------------------------------------------------------------------
 
 class TestBasisDecisionNote:
-    def test_skip_ratio_returns_skip_message(self):
-        note = _basis_decision_note(True, _BASE_SKIP_RATIO)
-        assert note is not None
-        assert "skipping Base entirely" in note
+    def test_basis_present_any_ratio_skip_note(self):
+        for ratio in (0.30, 0.50, 0.70, 0.95):
+            note = _basis_decision_note(True, ratio)
+            assert "basis present" in note
+            assert "skipping Base" in note
 
-    def test_above_skip_ratio(self):
-        note = _basis_decision_note(True, _BASE_SKIP_RATIO + 0.10)
-        assert note is not None
-        assert "skipping Base entirely" in note
+    def test_basis_absent_high_ratio_small_gap(self):
+        note = _basis_decision_note(False, 0.95)
+        assert "small" in note
 
-    def test_short_base_range(self):
-        ratio = (_BASE_SHORT_RATIO + _BASE_SKIP_RATIO) / 2  # midpoint
-        note = _basis_decision_note(True, ratio)
-        assert note is not None
-        assert "short Base" in note
+    def test_basis_absent_moderate_ratio(self):
+        note = _basis_decision_note(False, 0.80)
+        assert "moderate" in note
 
-    def test_below_short_ratio_full_base(self):
-        note = _basis_decision_note(True, _BASE_SHORT_RATIO - 0.10)
-        assert note is not None
-        assert "full Base" in note
+    def test_basis_absent_large_gap(self):
+        note = _basis_decision_note(False, 0.50)
+        assert "large" in note
 
-    def test_basis_absent_returns_none(self):
-        assert _basis_decision_note(False, 0.80) is None
+    def test_basis_none_uses_ratio(self):
+        assert "small" in _basis_decision_note(None, 0.95)
+        assert "moderate" in _basis_decision_note(None, 0.80)
+        assert "large" in _basis_decision_note(None, 0.50)
 
-    def test_basis_none_returns_none(self):
-        assert _basis_decision_note(None, 0.80) is None
+    def test_always_returns_string(self):
+        for bp in (True, False, None):
+            for ratio in (0.30, 0.70, 0.95):
+                note = _basis_decision_note(bp, ratio)
+                assert isinstance(note, str) and len(note) > 0

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -19,8 +19,11 @@ from intervals_mcp_server.tools.planning import (
     _assess_basis,
     _extract_30d_power,
     _determine_phases,
+    _basis_decision_note,
     _BASIS_20MIN_THRESHOLD,
     _BASIS_60MIN_THRESHOLD,
+    _BASE_SKIP_RATIO,
+    _BASE_SHORT_RATIO,
 )
 
 
@@ -149,30 +152,47 @@ import pytest
 
 
 class TestDeterminePhasesBasisPresent:
-    """basis_present=True: skip or shorten Base phase."""
+    """basis_present=True: three-tier Base selection."""
 
-    def test_basis_present_high_ratio_goes_to_build(self):
-        # ratio >= 0.70 + basis present → Build only (no Base)
+    def test_ratio_above_skip_threshold_no_base(self):
+        # ratio >= _BASE_SKIP_RATIO (0.70) → skip Base entirely
         phases = _determine_phases(20, current_ctl=80, goal_ctl=100, basis_present=True)
         names = [p for p, _ in phases]
         assert "base" not in names
         assert "build" in names
 
-    def test_basis_present_low_ratio_still_has_base(self):
-        # ratio < 0.70 + basis present → short Base then Build
-        phases = _determine_phases(20, current_ctl=50, goal_ctl=120, basis_present=True)
+    def test_ratio_exactly_at_skip_threshold_no_base(self):
+        # ratio == 0.70 exactly → still skip Base
+        phases = _determine_phases(20, current_ctl=70, goal_ctl=100, basis_present=True)
+        names = [p for p, _ in phases]
+        assert "base" not in names
+
+    def test_ratio_in_short_base_range_base_is_two_weeks(self):
+        # _BASE_SHORT_RATIO (0.50) <= ratio < _BASE_SKIP_RATIO (0.70) → 2-week Base
+        phases = _determine_phases(20, current_ctl=60, goal_ctl=100, basis_present=True)
         names = [p for p, _ in phases]
         assert "base" in names
-        assert "build" in names
-        # Base should be shorter than standard (≤ remaining // 3 equiv)
         base_wks = next(w for p, w in phases if p == "base")
-        build_wks = next(w for p, w in phases if p == "build")
-        # Short base: base_wks <= build_wks (build dominates)
-        assert build_wks >= base_wks
+        assert base_wks == 2
 
-    def test_basis_present_no_preparation_phase(self):
-        # Even with low ratio, basis_present skips Preparation
-        phases = _determine_phases(30, current_ctl=40, goal_ctl=120, basis_present=True)
+    def test_ratio_exactly_at_short_base_threshold(self):
+        # ratio == 0.50 → short Base (2 wk), not full
+        phases = _determine_phases(20, current_ctl=50, goal_ctl=100, basis_present=True)
+        base_wks = next(w for p, w in phases if p == "base")
+        assert base_wks == 2
+
+    def test_ratio_below_short_base_threshold_full_base(self):
+        # ratio < _BASE_SHORT_RATIO (0.50) → full Base (>= 3 wk), no Preparation
+        phases = _determine_phases(20, current_ctl=40, goal_ctl=120, basis_present=True)
+        names = [p for p, _ in phases]
+        assert "base" in names
+        assert "preparation" not in names
+        base_wks = next(w for p, w in phases if p == "base")
+        assert base_wks >= 3
+
+    def test_basis_present_never_adds_preparation(self):
+        # Even with very low ratio, basis_present should never produce Preparation
+        phases = _determine_phases(30, current_ctl=30, goal_ctl=120, basis_present=True)
         names = [p for p, _ in phases]
         assert "preparation" not in names
 
@@ -256,3 +276,36 @@ class TestDeterminePhasesEdgeCases:
             for total in (8, 16, 24, 32):
                 phases = _determine_phases(total, 60.0, 120.0, basis_present=basis)
                 assert sum(w for _, w in phases) == total
+
+
+# ---------------------------------------------------------------------------
+# _basis_decision_note
+# ---------------------------------------------------------------------------
+
+class TestBasisDecisionNote:
+    def test_skip_ratio_returns_skip_message(self):
+        note = _basis_decision_note(True, _BASE_SKIP_RATIO)
+        assert note is not None
+        assert "skipping Base entirely" in note
+
+    def test_above_skip_ratio(self):
+        note = _basis_decision_note(True, _BASE_SKIP_RATIO + 0.10)
+        assert note is not None
+        assert "skipping Base entirely" in note
+
+    def test_short_base_range(self):
+        ratio = (_BASE_SHORT_RATIO + _BASE_SKIP_RATIO) / 2  # midpoint
+        note = _basis_decision_note(True, ratio)
+        assert note is not None
+        assert "short Base" in note
+
+    def test_below_short_ratio_full_base(self):
+        note = _basis_decision_note(True, _BASE_SHORT_RATIO - 0.10)
+        assert note is not None
+        assert "full Base" in note
+
+    def test_basis_absent_returns_none(self):
+        assert _basis_decision_note(False, 0.80) is None
+
+    def test_basis_none_returns_none(self):
+        assert _basis_decision_note(None, 0.80) is None

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -5,6 +5,7 @@ Covers:
 - _assess_basis: all scenarios (present, absent, no data, no FTP)
 - _extract_30d_power: valid response, empty response, missing durations
 - _determine_phases with basis_present=True/False/None
+- next-Monday start-date logic
 """
 
 import os
@@ -301,3 +302,45 @@ class TestBasisDecisionNote:
             for ratio in (0.30, 0.70, 0.95):
                 note = _basis_decision_note(bp, ratio)
                 assert isinstance(note, str) and len(note) > 0
+
+
+# ---------------------------------------------------------------------------
+# Next-Monday start-date logic
+# ---------------------------------------------------------------------------
+
+from datetime import date, timedelta
+
+
+def _next_monday(today: date) -> date:
+    """Mirror the logic used in create_atp_plan."""
+    days_ahead = (7 - today.weekday()) % 7 or 7
+    return today + timedelta(days=days_ahead)
+
+
+class TestNextMondayStart:
+    def test_thursday_returns_next_monday(self):
+        thursday = date(2026, 6, 25)  # weekday() == 3
+        assert thursday.weekday() == 3
+        result = _next_monday(thursday)
+        assert result == date(2026, 6, 29)
+        assert result.weekday() == 0
+
+    def test_monday_returns_following_monday(self):
+        monday = date(2026, 6, 22)  # weekday() == 0
+        assert monday.weekday() == 0
+        result = _next_monday(monday)
+        assert result == date(2026, 6, 29)
+        assert result.weekday() == 0
+
+    def test_sunday_returns_tomorrow(self):
+        sunday = date(2026, 6, 28)  # weekday() == 6
+        result = _next_monday(sunday)
+        assert result == date(2026, 6, 29)
+        assert result.weekday() == 0
+
+    def test_result_is_always_in_the_future(self):
+        for offset in range(7):
+            today = date(2026, 6, 22) + timedelta(days=offset)
+            result = _next_monday(today)
+            assert result > today
+            assert result.weekday() == 0

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -1,0 +1,258 @@
+"""
+Unit tests for planning helpers in intervals_mcp_server.tools.planning.
+
+Covers:
+- _assess_basis: all scenarios (present, absent, no data, no FTP)
+- _extract_30d_power: valid response, empty response, missing durations
+- _determine_phases with basis_present=True/False/None
+"""
+
+import os
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+os.environ.setdefault("API_KEY", "test")
+os.environ.setdefault("ATHLETE_ID", "i1")
+
+from intervals_mcp_server.tools.planning import (
+    _assess_basis,
+    _extract_30d_power,
+    _determine_phases,
+    _BASIS_20MIN_THRESHOLD,
+    _BASIS_60MIN_THRESHOLD,
+)
+
+
+# ---------------------------------------------------------------------------
+# _assess_basis
+# ---------------------------------------------------------------------------
+
+class TestAssessBasis:
+    def test_basis_present_with_ftp(self):
+        ftp = 300
+        power_20 = ftp * _BASIS_20MIN_THRESHOLD  # exactly at threshold
+        power_60 = ftp * _BASIS_60MIN_THRESHOLD
+        basis, ftp_ref, r20, r60 = _assess_basis(power_20, power_60, ftp)
+        assert basis is True
+        assert ftp_ref == float(ftp)
+        assert abs(r20 - _BASIS_20MIN_THRESHOLD) < 0.001
+        assert abs(r60 - _BASIS_60MIN_THRESHOLD) < 0.001
+
+    def test_basis_absent_weak_20min(self):
+        ftp = 300
+        power_20 = ftp * (_BASIS_20MIN_THRESHOLD - 0.05)  # below threshold
+        power_60 = ftp * _BASIS_60MIN_THRESHOLD
+        basis, _, r20, _ = _assess_basis(power_20, power_60, ftp)
+        assert basis is False
+        assert r20 < _BASIS_20MIN_THRESHOLD
+
+    def test_basis_absent_weak_60min(self):
+        ftp = 300
+        power_20 = ftp * _BASIS_20MIN_THRESHOLD
+        power_60 = ftp * (_BASIS_60MIN_THRESHOLD - 0.05)  # below threshold
+        basis, _, _, r60 = _assess_basis(power_20, power_60, ftp)
+        assert basis is False
+        assert r60 < _BASIS_60MIN_THRESHOLD
+
+    def test_no_data_returns_none(self):
+        basis, ftp_ref, r20, r60 = _assess_basis(None, None, 300)
+        assert basis is None
+        assert ftp_ref is None
+        assert r20 is None
+        assert r60 is None
+
+    def test_ftp_proxy_from_20min(self):
+        """When FTP is not given, use 20-min power × 0.95 as proxy."""
+        power_20 = 300.0
+        # 60-min must be >= proxy * threshold = 285 * 0.75 = 213.75
+        power_60 = 220.0
+        basis, ftp_ref, r20, r60 = _assess_basis(power_20, power_60, ftp=None)
+        assert ftp_ref == pytest.approx(power_20 * 0.95)
+        # 20-min ratio: 300 / 285 ≈ 1.053 → above threshold
+        assert r20 is not None and r20 > _BASIS_20MIN_THRESHOLD
+        assert basis is True
+
+    def test_ftp_proxy_basis_absent(self):
+        """Proxy FTP: 20-min power is by definition 5% above proxy, but 60-min may fail."""
+        power_20 = 300.0
+        power_60 = 100.0  # far below threshold
+        basis, _, _, r60 = _assess_basis(power_20, power_60, ftp=None)
+        assert basis is False
+        assert r60 < _BASIS_60MIN_THRESHOLD
+
+    def test_only_20min_available(self):
+        """60-min missing → cannot fully confirm basis."""
+        basis, _, r20, r60 = _assess_basis(280.0, None, ftp=300)
+        assert basis is False  # meets_60 is False because r60 is None
+        assert r20 is not None
+        assert r60 is None
+
+    def test_only_60min_no_ftp(self):
+        """No 20-min and no FTP → cannot derive ftp_ref → None."""
+        basis, ftp_ref, _, _ = _assess_basis(None, 240.0, ftp=None)
+        assert basis is None
+        assert ftp_ref is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_30d_power
+# ---------------------------------------------------------------------------
+
+def _make_curve_response(secs: list[int], values: list[float | None]) -> dict:
+    return {"list": [{"secs": secs, "values": values}]}
+
+
+class TestExtract30dPower:
+    def test_extracts_20min_and_60min(self):
+        secs = [60, 300, 1200, 3600]
+        values = [500.0, 420.0, 320.0, 280.0]
+        p20, p60 = _extract_30d_power(_make_curve_response(secs, values))
+        assert p20 == pytest.approx(320.0)
+        assert p60 == pytest.approx(280.0)
+
+    def test_missing_60min_returns_none(self):
+        secs = [60, 1200]
+        values = [500.0, 320.0]
+        p20, p60 = _extract_30d_power(_make_curve_response(secs, values))
+        assert p20 == pytest.approx(320.0)
+        assert p60 is None
+
+    def test_empty_list_returns_none(self):
+        p20, p60 = _extract_30d_power({"list": []})
+        assert p20 is None
+        assert p60 is None
+
+    def test_error_response_returns_none(self):
+        p20, p60 = _extract_30d_power({"error": "Not found"})
+        assert p20 is None
+        assert p60 is None
+
+    def test_non_dict_returns_none(self):
+        p20, p60 = _extract_30d_power(None)
+        assert p20 is None
+        assert p60 is None
+
+    def test_null_value_returns_none(self):
+        secs = [1200, 3600]
+        values = [None, 280.0]
+        p20, p60 = _extract_30d_power(_make_curve_response(secs, values))
+        assert p20 is None
+        assert p60 == pytest.approx(280.0)
+
+
+# ---------------------------------------------------------------------------
+# _determine_phases with basis_present
+# ---------------------------------------------------------------------------
+
+import pytest
+
+
+class TestDeterminePhasesBasisPresent:
+    """basis_present=True: skip or shorten Base phase."""
+
+    def test_basis_present_high_ratio_goes_to_build(self):
+        # ratio >= 0.70 + basis present → Build only (no Base)
+        phases = _determine_phases(20, current_ctl=80, goal_ctl=100, basis_present=True)
+        names = [p for p, _ in phases]
+        assert "base" not in names
+        assert "build" in names
+
+    def test_basis_present_low_ratio_still_has_base(self):
+        # ratio < 0.70 + basis present → short Base then Build
+        phases = _determine_phases(20, current_ctl=50, goal_ctl=120, basis_present=True)
+        names = [p for p, _ in phases]
+        assert "base" in names
+        assert "build" in names
+        # Base should be shorter than standard (≤ remaining // 3 equiv)
+        base_wks = next(w for p, w in phases if p == "base")
+        build_wks = next(w for p, w in phases if p == "build")
+        # Short base: base_wks <= build_wks (build dominates)
+        assert build_wks >= base_wks
+
+    def test_basis_present_no_preparation_phase(self):
+        # Even with low ratio, basis_present skips Preparation
+        phases = _determine_phases(30, current_ctl=40, goal_ctl=120, basis_present=True)
+        names = [p for p, _ in phases]
+        assert "preparation" not in names
+
+
+class TestDeterminePhasesBasisAbsent:
+    """basis_present=False: force Base even when CTL ratio is high."""
+
+    def test_basis_absent_high_ratio_adds_base(self):
+        # ratio >= 0.90 but no recent riding → should add Base
+        phases = _determine_phases(20, current_ctl=95, goal_ctl=100, basis_present=False)
+        names = [p for p, _ in phases]
+        assert "base" in names
+
+    def test_basis_absent_moderate_ratio_adds_base(self):
+        # ratio 70–90% + basis absent → Base + Build
+        phases = _determine_phases(20, current_ctl=75, goal_ctl=100, basis_present=False)
+        names = [p for p, _ in phases]
+        assert "base" in names
+        assert "build" in names
+
+    def test_basis_absent_low_ratio_full_plan(self):
+        # ratio < 0.70 + basis absent → Prep + Base + Build
+        phases = _determine_phases(30, current_ctl=40, goal_ctl=120, basis_present=False)
+        names = [p for p, _ in phases]
+        assert "preparation" in names
+        assert "base" in names
+        assert "build" in names
+
+
+class TestDeterminePhasesBasisNone:
+    """basis_present=None: original CTL-gap logic, unchanged."""
+
+    def test_none_high_ratio_straight_to_build(self):
+        phases = _determine_phases(20, current_ctl=95, goal_ctl=100, basis_present=None)
+        names = [p for p, _ in phases]
+        assert "base" not in names
+        assert "build" in names
+
+    def test_none_moderate_ratio_base_plus_build(self):
+        phases = _determine_phases(20, current_ctl=75, goal_ctl=100, basis_present=None)
+        names = [p for p, _ in phases]
+        assert "base" in names
+        assert "build" in names
+
+    def test_none_low_ratio_full_plan(self):
+        phases = _determine_phases(30, current_ctl=40, goal_ctl=120, basis_present=None)
+        names = [p for p, _ in phases]
+        assert "preparation" in names
+        assert "base" in names
+        assert "build" in names
+
+    def test_none_is_default_parameter(self):
+        """Omitting basis_present gives same result as None."""
+        phases_explicit = _determine_phases(20, 75.0, 100.0, basis_present=None)
+        phases_default = _determine_phases(20, 75.0, 100.0)
+        assert phases_explicit == phases_default
+
+
+class TestDeterminePhasesEdgeCases:
+    def test_short_plan_ignores_basis(self):
+        # remaining <= 4: always collapse to build, ignore basis signal
+        phases_t = _determine_phases(7, 50.0, 120.0, basis_present=True)
+        phases_f = _determine_phases(7, 50.0, 120.0, basis_present=False)
+        # Both should have build (not base+build) since remaining is small
+        # peak=2, race=1 → remaining=4
+        names_t = [p for p, _ in phases_t]
+        names_f = [p for p, _ in phases_f]
+        assert "build" in names_t
+        assert "build" in names_f
+
+    def test_peak_and_race_always_present(self):
+        for basis in (True, False, None):
+            phases = _determine_phases(20, 80.0, 100.0, basis_present=basis)
+            names = [p for p, _ in phases]
+            assert "peak" in names
+            assert "race" in names
+
+    def test_total_weeks_preserved(self):
+        """Sum of all phase weeks must equal total_weeks."""
+        for basis in (True, False, None):
+            for total in (8, 16, 24, 32):
+                phases = _determine_phases(total, 60.0, 120.0, basis_present=basis)
+                assert sum(w for _, w in phases) == total

--- a/uv.lock
+++ b/uv.lock
@@ -352,11 +352,6 @@ dev = [
     { name = "ruff" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "hatch", marker = "extra == 'dev'" },
@@ -371,9 +366,6 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]
 provides-extras = ["dev"]
-
-[package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.1" }]
 
 [[package]]
 name = "jaraco-classes"


### PR DESCRIPTION
## Summary

This PR adds a new `planning` module with five MCP tools that give an AI assistant full season-planning capabilities on top of the Intervals.icu calendar.

### New tools

#### `create_atp_plan`
Builds a complete Annual Training Plan from today up to an A-race date.

- Fetches the athlete's current CTL from the wellness API
- Selects phases automatically based on the ratio `current_ctl / goal_ctl` (scales to any athlete level — no hardcoded thresholds):
  - ≥ 90 % → Build → Peak → Race
  - 70–90 % → Base → Build → Peak → Race
  - < 70 % → Preparation → Base → Build → Peak → Race
- Posts one NOTE event per phase to the Intervals.icu calendar, each containing: phase label, date range, training focus, intensity split, key sessions, and weekly TSS target
- Every 4th week is automatically marked as a recovery week (70 % TSS)
- Includes a human-readable explanation of why those phases were chosen

#### `get_atp_plan`
Reads all ATP phase notes from the calendar for a given date range and returns a structured overview of the season plan.

#### `get_atp_week_note`
Returns the ATP phase note for the week containing a given date — useful for week-by-week planning context (phase focus, TSS target, key sessions).

#### `get_planning_context`
One-shot context snapshot for planning a specific week, combining:
- Current CTL / ATL / TSB / HRV from the last 14 days of wellness data
- The ATP phase note for that week
- Planned workouts for that week
- Upcoming races within the next 120 days

#### `add_race_event`
Creates a race event on the calendar with the correct Intervals.icu fields:
- `category`: `RACE_A`, `RACE_B`, or `RACE_C` (priority embedded in category name)
- `type`: sport (Ride, Run, Swim, …)
- `start_date_local`: `YYYY-MM-DDTHH:MM:SS`
- `moving_time`: expected duration in seconds
- `distance`: meters
- `icu_training_load`: expected TSS

### Other changes
- `tools/__init__.py`: registers all five new tools for export
- `tools/power_curves.py`: removed genuinely unused import flagged by ruff
- `tools/server.py`: added `# noqa: F401` to preserve deliberate re-export of `get_gear_list` for test compatibility
- All tool output is in English

## Test plan
- [x] `create_atp_plan` with a race date 8–24 weeks out at varying CTL levels (high/mid/low ratio) — verify correct phase selection and NOTE events on calendar
- [x] `get_atp_plan` after creating a plan — verify all phase notes are returned
- [x] `get_atp_week_note` for a date inside each phase — verify correct note is returned
- [x] `get_planning_context` — verify CTL/ATL/TSB, ATP note, workouts and races all appear
- [x] `add_race_event` with priority A, B and C — verify correct category saved by API
- [x] `ruff check src/`, `mypy src tests`, `pytest` all pass ✅ (verified before each commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)