### PR TITLE
fix: prevent OpenAPI generation crash due to recursive schema

### DIFF
--- a/src/intervals_mcp_server/tools/events.py
+++ b/src/intervals_mcp_server/tools/events.py
@@ -283,7 +283,7 @@ async def add_or_update_event(  # pylint: disable=too-many-arguments,too-many-po
         event_id: The Intervals.icu event ID (optional, will use event_id from .env if not provided)
         start_date: Start date in YYYY-MM-DD format (optional, defaults to today)
         name: Name of the activity
-        workout_doc: steps as a list of Step objects (optional, but necessary to define workout steps)
+        workout_doc: Generic workout document object (optional, but necessary to define workout steps)
         workout_type: Workout type (e.g. Ride, Run, Swim, Walk, Row)
         moving_time: Total expected moving time of the workout in seconds (optional)
         distance: Total expected distance of the workout in meters (optional)

--- a/src/intervals_mcp_server/tools/events.py
+++ b/src/intervals_mcp_server/tools/events.py
@@ -12,7 +12,7 @@ from intervals_mcp_server.api.client import make_intervals_request
 from intervals_mcp_server.config import get_config
 from intervals_mcp_server.utils.dates import get_default_end_date, get_default_future_end_date
 from intervals_mcp_server.utils.formatting import format_event_details, format_event_summary
-from intervals_mcp_server.utils.types import WorkoutDoc
+
 from intervals_mcp_server.utils.validation import resolve_activity_type, resolve_athlete_id, validate_date
 
 # Import mcp instance from shared module for tool registration
@@ -25,7 +25,7 @@ def _prepare_event_data(  # pylint: disable=too-many-arguments,too-many-position
     name: str,
     workout_type: str,
     start_date: str,
-    workout_doc: WorkoutDoc | None,
+    workout_doc: dict[str, Any] | None,
     moving_time: int | None,
     distance: int | None,
 ) -> dict[str, Any]:
@@ -268,7 +268,7 @@ async def add_or_update_event(  # pylint: disable=too-many-arguments,too-many-po
     api_key: str | None = None,
     event_id: str | None = None,
     start_date: str | None = None,
-    workout_doc: WorkoutDoc | None = None,
+    workout_doc: dict[str, Any] | None = None,
     moving_time: int | None = None,
     distance: int | None = None,
 ) -> str:


### PR DESCRIPTION
Replaces the strict `WorkoutDoc` dataclass with a generic `dict[str, Any]`. The original `WorkoutDoc` dataclass contained a self-referencing `Step` property. This structure causes infinite recursion in OpenAPI schema generators (like `mcpo`), leading to `RecursionError` crashes when mounting the MCP server.

I investigated the crash logs from `mcpo` and traced the recursion directly to the `Step` list nested within itself. Reviewing the official Intervals.icu OpenAPI specification (`intervals openapi-spec.json`) basically revealed that the official API defines `workout_doc` as a generic object (`{"type": "object", "additionalProperties": {"type": "object"}}`), rather than a strictly typed nested array. 

This change drops the custom Python type and aligns the tool parameter with the official API spec. It prevents schema parser crashes while preserving the functionality, as the parameter is stringified before transmission.