### PR TITLE
[intervals-mcp-server] Scope delete_events_by_date_range by category

### DIFF
--- a/src/intervals_mcp_server/tools/events.py
+++ b/src/intervals_mcp_server/tools/events.py
@@ -230,12 +230,35 @@ async def _fetch_events_for_deletion(
     return events, None
 
 
+def _filter_events_by_category(
+    events: list[dict[str, Any]], category: str | None
+) -> list[dict[str, Any]]:
+    """Restrict events to a single category (case-insensitive).
+
+    When *category* is None the input is returned unchanged so the caller keeps
+    the prior behaviour. Events missing the ``category`` field are excluded
+    when a category filter is supplied — better to skip than to delete an
+    event whose category cannot be confirmed.
+    """
+    if category is None:
+        return events
+    target = category.upper()
+    return [
+        event
+        for event in events
+        if isinstance(event, dict)
+        and isinstance(event.get("category"), str)
+        and event["category"].upper() == target
+    ]
+
+
 @mcp.tool()
 async def delete_events_by_date_range(
     start_date: str,
     end_date: str,
     athlete_id: str | None = None,
     api_key: str | None = None,
+    category: str | None = None,
 ) -> str:
     """Delete events for an athlete from Intervals.icu in the specified date range.
 
@@ -244,6 +267,8 @@ async def delete_events_by_date_range(
         api_key: The Intervals.icu API key (optional, will use API_KEY from .env if not provided)
         start_date: Start date in YYYY-MM-DD format
         end_date: End date in YYYY-MM-DD format
+        category: Restrict deletion to one event category (e.g. "WORKOUT", "RACE", "NOTE").
+            Case-insensitive. When omitted, every category in the range is deleted.
     """
     athlete_id_to_use, error_msg = resolve_athlete_id(athlete_id, config.athlete_id)
     if error_msg:
@@ -255,9 +280,14 @@ async def delete_events_by_date_range(
     if error_msg:
         return error_msg
 
-    failed_events = await _delete_events_list(athlete_id_to_use, api_key, events)
-    deleted_count = len(events) - len(failed_events)
-    return f"Deleted {deleted_count} events. Failed to delete {len(failed_events)} events: {failed_events}"
+    scoped_events = _filter_events_by_category(events, category)
+    failed_events = await _delete_events_list(athlete_id_to_use, api_key, scoped_events)
+    deleted_count = len(scoped_events) - len(failed_events)
+    scope_note = f" {category.upper()}" if category else ""
+    return (
+        f"Deleted {deleted_count}{scope_note} events. "
+        f"Failed to delete {len(failed_events)} events: {failed_events}"
+    )
 
 
 @mcp.tool()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -33,6 +33,7 @@ from intervals_mcp_server.server import (  # pylint: disable=wrong-import-positi
     get_activity_messages,
     get_activity_streams,
     add_or_update_event,
+    delete_events_by_date_range,
     get_athlete_power_curves,
     get_event_by_id,
     get_events,
@@ -949,3 +950,64 @@ def test_get_activities_resolves_gear_name(monkeypatch):
     assert "Ride 2" in result
     assert "Name: Litening Air" in result
     assert "Name: S-Works Tarmac SL8" in result
+
+
+# ---------------------------------------------------------------------------
+# delete_events_by_date_range
+# ---------------------------------------------------------------------------
+
+
+def test_delete_events_by_date_range_respects_category(monkeypatch):
+    """Deleting a range with category=WORKOUT must only delete workout events.
+
+    Races, notes, and other categories in the same range must be left alone.
+    """
+    events = [
+        {"id": 1, "category": "WORKOUT", "name": "Easy run"},
+        {"id": 2, "category": "RACE", "name": "Goal race"},
+        {"id": 3, "category": "NOTE", "name": "Travel"},
+        {"id": 4, "category": "WORKOUT", "name": "Intervals"},
+    ]
+    deleted_ids: list[str] = []
+
+    async def fake_request(*_args, **kwargs):
+        if kwargs.get("method") == "DELETE":
+            deleted_ids.append(kwargs["url"])
+            return {}
+        return events
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.events.make_intervals_request", fake_request
+    )
+    result = asyncio.run(
+        delete_events_by_date_range(
+            start_date="2024-01-01", end_date="2024-01-07", athlete_id="1", category="WORKOUT"
+        )
+    )
+    assert deleted_ids == ["/athlete/1/events/1", "/athlete/1/events/4"]
+    assert "Deleted 2" in result
+
+
+def test_delete_events_by_date_range_category_no_match_deletes_nothing(monkeypatch):
+    """When no event matches the requested category, nothing must be deleted."""
+    events = [{"id": 1, "category": "RACE", "name": "Goal race"}]
+    deleted_ids: list[str] = []
+
+    async def fake_request(*_args, **kwargs):
+        if kwargs.get("method") == "DELETE":
+            deleted_ids.append(kwargs["url"])
+            return {}
+        return events
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.events.make_intervals_request", fake_request
+    )
+    result = asyncio.run(
+        delete_events_by_date_range(
+            start_date="2024-01-01", end_date="2024-01-07", athlete_id="1", category="WORKOUT"
+        )
+    )
+    assert deleted_ids == []
+    assert "Deleted 0" in result


### PR DESCRIPTION
## Summary

`delete_events_by_date_range` previously issued one DELETE per event in the date range with no category filter, destroying races, notes, and rest days alongside the workouts an LLM caller almost always intends to clear. The success message only counted events and listed failed IDs, so callers could not tell what was destroyed.

This change adds an optional `category` parameter and a client-side filter so destructive range deletes are scoped by default.

## Root cause

`src/intervals_mcp_server/tools/events.py:223` — `_fetch_events_for_deletion` built params `{"oldest": ..., "newest": ...}` with no `category` filter, and `_delete_events_list` (line 65) iterated the response, DELETing every event. Data loss was irreversible and silent on the category axis.

## Fix

- Add optional `category` parameter to `delete_events_by_date_range` (case-insensitive).
- Client-side filter via a new `_filter_events_by_category` helper, robust without depending on undocumented API query params.
- Events whose `category` field is missing are skipped when a filter is supplied: safer to skip than delete an unverified event.
- Result message reports the active scope, e.g. `Deleted 3 WORKOUT events. Failed to delete 0 events: []`.

## Tests

- `test_delete_events_by_date_range_respects_category` — mixed categories (WORKOUT/RACE/NOTE); with `category="WORKOUT"` only the workout IDs are DELETEd.
- `test_delete_events_by_date_range_category_no_match_deletes_nothing` — no-match path issues zero DELETE calls.

## Verification

- `uv run pytest` → 63 passed (61 prior + 2 new).
- `uv run ruff check .` → 2 pre-existing F401 unused-imports (`get_gear_list` in `server.py:88`, `resolve_activity_type` in `power_curves.py:14`), untouched by this change.
- `uv run mypy src tests` → clean.

## Notes for reviewer

Default behaviour of `delete_events_by_date_range` (no `category` arg) is unchanged to avoid silently breaking existing callers. The new parameter is the recommended path.