### PR TITLE
Add update activity

### DIFF
--- a/src/intervals_mcp_server/api/client.py
+++ b/src/intervals_mcp_server/api/client.py
@@ -154,7 +154,7 @@ async def make_intervals_request(
     api_key: str | None = None,
     params: dict[str, Any] | None = None,
     method: str = "GET",
-    data: dict[str, Any] | None = None,
+    data: dict[str, Any] | list[dict[str, Any]] | None = None,
 ) -> dict[str, Any] | list[dict[str, Any]]:
     """
     Make a request to the Intervals.icu API with proper error handling.

--- a/src/intervals_mcp_server/server.py
+++ b/src/intervals_mcp_server/server.py
@@ -97,6 +97,10 @@ from intervals_mcp_server.tools.custom_items import (  # pylint: disable=wrong-i
     get_custom_items,
     update_custom_item,
 )
+from intervals_mcp_server.tools.sport_settings import (  # pylint: disable=wrong-import-position  # noqa: E402
+    get_sport_settings,
+    update_sport_settings,
+)
 
 # Re-export make_intervals_request and httpx_client for backward compatibility
 # pylint: disable=duplicate-code  # This __all__ list is intentionally similar to tools/__init__.py
@@ -122,10 +126,11 @@ __all__ = [
     "create_custom_item",
     "update_custom_item",
     "delete_custom_item",
+    "get_sport_settings",
+    "update_sport_settings",
 ]
 
 
-# Run the server
 if __name__ == "__main__":
     # Validate ATHLETE_ID when server starts (not at import time to allow tests)
     validate_athlete_id(config.athlete_id)

--- a/src/intervals_mcp_server/server.py
+++ b/src/intervals_mcp_server/server.py
@@ -28,6 +28,10 @@ Usage:
         - get_activity_messages
         - add_activity_message
         - update_activity
+        - get_sport_settings
+        - update_sport_settings
+        - get_gear_list
+        - update_wellness_data
         - get_events
         - get_event_by_id
         - add_or_update_event
@@ -88,7 +92,7 @@ from intervals_mcp_server.tools.events import (  # pylint: disable=wrong-import-
     get_events,
 )
 from intervals_mcp_server.tools.gear import get_gear_list  # pylint: disable=wrong-import-position  # noqa: E402
-from intervals_mcp_server.tools.wellness import get_wellness_data  # pylint: disable=wrong-import-position  # noqa: E402
+from intervals_mcp_server.tools.wellness import get_wellness_data, update_wellness_data  # pylint: disable=wrong-import-position  # noqa: E402
 from intervals_mcp_server.tools.power_curves import get_athlete_power_curves  # pylint: disable=wrong-import-position  # noqa: E402
 from intervals_mcp_server.tools.custom_items import (  # pylint: disable=wrong-import-position  # noqa: E402
     create_custom_item,
@@ -120,7 +124,9 @@ __all__ = [
     "delete_events_by_date_range",
     "add_or_update_event",
     "get_wellness_data",
+    "update_wellness_data",
     "get_athlete_power_curves",
+    "get_gear_list",
     "get_custom_items",
     "get_custom_item_by_id",
     "create_custom_item",

--- a/src/intervals_mcp_server/server.py
+++ b/src/intervals_mcp_server/server.py
@@ -27,6 +27,7 @@ Usage:
         - get_activity_streams
         - get_activity_messages
         - add_activity_message
+        - update_activity
         - get_events
         - get_event_by_id
         - add_or_update_event
@@ -77,6 +78,7 @@ from intervals_mcp_server.tools.activities import (  # pylint: disable=wrong-imp
     get_activity_intervals,
     get_activity_messages,
     get_activity_streams,
+    update_activity,
 )
 from intervals_mcp_server.tools.events import (  # pylint: disable=wrong-import-position  # noqa: E402
     add_or_update_event,
@@ -102,6 +104,7 @@ __all__ = [
     "make_intervals_request",
     "httpx_client",  # Re-exported for test compatibility
     "add_activity_message",
+    "update_activity",
     "get_activities",
     "get_activity_details",
     "get_activity_intervals",

--- a/src/intervals_mcp_server/tools/__init__.py
+++ b/src/intervals_mcp_server/tools/__init__.py
@@ -32,7 +32,11 @@ from intervals_mcp_server.tools.power_curves import (  # noqa: F401
     get_athlete_power_curves,
 )
 from intervals_mcp_server.tools.gear import get_gear_list  # noqa: F401
-from intervals_mcp_server.tools.wellness import get_wellness_data  # noqa: F401
+from intervals_mcp_server.tools.wellness import get_wellness_data, update_wellness_data  # noqa: F401
+from intervals_mcp_server.tools.sport_settings import (  # noqa: F401
+    get_sport_settings,
+    update_sport_settings,
+)
 
 
 def register_tools(mcp_instance: FastMCP) -> None:
@@ -70,4 +74,7 @@ __all__ = [
     "get_athlete_power_curves",
     "get_gear_list",
     "get_wellness_data",
+    "update_wellness_data",
+    "get_sport_settings",
+    "update_sport_settings",
 ]

--- a/src/intervals_mcp_server/tools/activities.py
+++ b/src/intervals_mcp_server/tools/activities.py
@@ -414,8 +414,8 @@ async def update_activity(  # pylint: disable=too-many-arguments,too-many-positi
         activity_id: The Intervals.icu activity ID
         name: New name/title for the activity (optional)
         description: New description for the activity (optional)
-        icu_rpe: Rating of Perceived Exertion, 1-10 (optional)
-        feel: How the athlete felt, 1-5 where 1=strong 5=weak (optional)
+        icu_rpe: Rating of Perceived Exertion on the CR-10 (Borg) scale: 1=Nothing at all, 2=Very easy, 3=Easy, 4=Comfortable, 5=Slightly challenging, 6=Difficult, 7=Hard, 8=Very hard, 9=Extremely hard, 10=Max effort (optional)
+        feel: How the athlete felt on a 1-5 scale: 1=Strong, 2=Good, 3=Normal, 4=Poor, 5=Weak (optional). As shown in the Intervals.icu UI with smiley faces from very happy to sad/X-eyes.
         trainer: Whether the activity was on a trainer (optional, bool)
         sport_type: Sport type — common values: Ride, Run, Swim, Walk, Row,
                     VirtualRide, MountainBikeRide, GravelRide, Workout (optional).

--- a/src/intervals_mcp_server/tools/activities.py
+++ b/src/intervals_mcp_server/tools/activities.py
@@ -392,3 +392,74 @@ async def add_activity_message(
     if msg_id is not None:
         return f"Successfully added message (ID: {msg_id}) to activity {activity_id}."
     return f"Message appears to have been added to activity {activity_id}, but no ID was returned. Please verify manually."
+
+
+@mcp.tool()
+async def update_activity(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    activity_id: str,
+    name: str | None = None,
+    description: str | None = None,
+    icu_rpe: int | None = None,
+    feel: int | None = None,
+    trainer: bool | None = None,
+    sport_type: str | None = None,
+    gear_id: int | None = None,
+    api_key: str | None = None,
+) -> str:
+    """Update metadata fields on an existing activity in Intervals.icu
+
+    Only the fields you provide are updated — unspecified fields are left unchanged.
+
+    Args:
+        activity_id: The Intervals.icu activity ID
+        name: New name/title for the activity (optional)
+        description: New description for the activity (optional)
+        icu_rpe: Rating of Perceived Exertion, 1-10 (optional)
+        feel: How the athlete felt, 1-5 where 1=strong 5=weak (optional)
+        trainer: Whether the activity was on a trainer (optional, bool)
+        sport_type: Sport type — common values: Ride, Run, Swim, Walk, Row,
+                    VirtualRide, MountainBikeRide, GravelRide, Workout (optional).
+                    Invalid types are rejected by the API.
+        gear_id: Gear/bike ID from the athlete's equipment list (optional).
+                 Use `get_gear` to list available gear IDs.
+        api_key: The Intervals.icu API key (optional, will use API_KEY from .env if not provided)
+    """
+    # Build payload with only the fields the caller explicitly set
+    payload: dict[str, Any] = {}
+    if name is not None:
+        payload["name"] = name
+    if description is not None:
+        payload["description"] = description
+    if icu_rpe is not None:
+        payload["icu_rpe"] = icu_rpe
+    if feel is not None:
+        payload["feel"] = feel
+    if trainer is not None:
+        payload["trainer"] = trainer
+    if sport_type is not None:
+        payload["sport_type"] = sport_type
+    if gear_id is not None:
+        payload["gear_id"] = gear_id
+
+    if not payload:
+        return "Error: No fields to update. Provide at least one of the optional fields."
+
+    result = await make_intervals_request(
+        url=f"/activity/{activity_id}",
+        api_key=api_key,
+        method="PUT",
+        data=payload,
+    )
+
+    if isinstance(result, dict) and "error" in result:
+        error_message = result.get("message", "Unknown error")
+        return f"Error updating activity: {error_message}"
+
+    if not result or not isinstance(result, dict):
+        return "Error: Unexpected response when updating activity."
+
+    updated_id = result.get("id")
+    if updated_id is not None:
+        updated_fields = list(payload)
+        return f"Successfully updated activity {activity_id} ({', '.join(updated_fields)})."
+    return f"Activity {activity_id} appears to have been updated, but no ID was returned. Please verify manually."

--- a/src/intervals_mcp_server/tools/power_curves.py
+++ b/src/intervals_mcp_server/tools/power_curves.py
@@ -11,7 +11,7 @@ from typing import Any
 from intervals_mcp_server.api.client import make_intervals_request
 from intervals_mcp_server.config import get_config
 from intervals_mcp_server.utils.formatting import format_power_curves
-from intervals_mcp_server.utils.validation import resolve_activity_type, resolve_athlete_id
+from intervals_mcp_server.utils.validation import resolve_athlete_id
 
 # Import mcp instance from shared module for tool registration
 from intervals_mcp_server.mcp_instance import mcp  # noqa: F401

--- a/src/intervals_mcp_server/tools/sport_settings.py
+++ b/src/intervals_mcp_server/tools/sport_settings.py
@@ -1,0 +1,181 @@
+"""
+Sport settings MCP tools for Intervals.icu.
+
+This module contains tools for retrieving and updating athlete sport settings
+(FTP, LTHR, max HR, power zones, etc.).
+"""
+
+from typing import Any
+
+from intervals_mcp_server.api.client import make_intervals_request
+from intervals_mcp_server.config import get_config
+from intervals_mcp_server.utils.validation import resolve_athlete_id
+
+# Import mcp instance from shared module for tool registration
+from intervals_mcp_server.mcp_instance import mcp  # noqa: F401
+
+config = get_config()
+
+
+@mcp.tool()
+async def get_sport_settings(
+    sport_type: str = "Ride",
+    athlete_id: str | None = None,
+    api_key: str | None = None,
+) -> str:
+    """Get current sport settings (FTP, LTHR, zones, etc.) for a sport.
+
+    Args:
+        sport_type: Sport type identifier (e.g. "Ride", "Run", "Swim"). Defaults to "Ride".
+                   Matches the sport settings grouping in Intervals.icu.
+        athlete_id: The Intervals.icu athlete ID (optional, will use ATHLETE_ID from .env if not provided)
+        api_key: The Intervals.icu API key (optional, will use API_KEY from .env if not provided)
+
+    Returns:
+        Formatted string with current sport settings.
+    """
+    athlete_id_to_use, error_msg = resolve_athlete_id(athlete_id, config.athlete_id)
+    if error_msg:
+        return error_msg
+
+    # List all sport settings to find the one matching our sport type
+    result = await make_intervals_request(
+        url=f"/athlete/{athlete_id_to_use}/sport-settings",
+        api_key=api_key,
+    )
+
+    if isinstance(result, dict) and "error" in result:
+        error_message = result.get("message", "Unknown error")
+        return f"Error fetching sport settings: {error_message}"
+
+    if not isinstance(result, list):
+        return "Error: Unexpected response when fetching sport settings."
+
+    # Find the settings matching the requested sport type
+    for settings in result:
+        types = settings.get("types", [])
+        if sport_type in types:
+            output_parts = [f"Sport settings for {sport_type}:"]
+            useful_fields = [
+                ("ftp", "FTP (W)"),
+                ("indoor_ftp", "Indoor FTP (W)"),
+                ("lthr", "LTHR (bpm)"),
+                ("max_hr", "Max HR (bpm)"),
+                ("p_max", "Pmax (W)"),
+                ("w_prime", "W' (kJ)"),
+                ("sweet_spot_min", "Sweet Spot Min (%FTP)"),
+                ("sweet_spot_max", "Sweet Spot Max (%FTP)"),
+                ("threshold_pace", "Threshold Pace"),
+                ("hr_load_type", "HR Load Type"),
+                ("gap_model", "GAP Model"),
+            ]
+            for field_key, field_label in useful_fields:
+                value = settings.get(field_key)
+                if value is not None:
+                    output_parts.append(f"  {field_label}: {value}")
+
+            hr_zones = settings.get("hr_zones")
+            if hr_zones:
+                zone_labels = settings.get("hr_zone_names", [])
+                parts = []
+                for i, zone in enumerate(hr_zones):
+                    label = zone_labels[i] if i < len(zone_labels) else f"Zone {i + 1}"
+                    parts.append(f"{label}: {zone}")
+                output_parts.append(f"  HR Zones: {', '.join(parts)}")
+
+            power_zones = settings.get("power_zones")
+            if power_zones:
+                zone_labels = settings.get("power_zone_names", [])
+                parts = []
+                for i, zone in enumerate(power_zones):
+                    label = zone_labels[i] if i < len(zone_labels) else f"Zone {i + 1}"
+                    parts.append(f"{label}: {zone}")
+                output_parts.append(f"  Power Zones: {', '.join(parts)}")
+
+            default_gear = settings.get("default_gear_id")
+            if default_gear:
+                output_parts.append(f"  Default Gear ID: {default_gear}")
+            indoor_gear = settings.get("default_indoor_gear_id")
+            if indoor_gear:
+                output_parts.append(f"  Default Indoor Gear ID: {indoor_gear}")
+
+            return "\n".join(output_parts)
+
+    return (f"No sport settings found for '{sport_type}'. "
+            f"Available types are defined in the activity types for each sport settings record.")
+
+
+@mcp.tool()
+async def update_sport_settings(
+    sport_type: str = "Ride",
+    ftp: int | None = None,
+    indoor_ftp: int | None = None,
+    lthr: int | None = None,
+    max_hr: int | None = None,
+    p_max: int | None = None,
+    w_prime: int | None = None,
+    athlete_id: str | None = None,
+    api_key: str | None = None,
+) -> str:
+    """Update sport settings (FTP, LTHR, etc.) for a sport type.
+
+    Only the fields you provide are updated — unspecified fields are left unchanged.
+
+    Args:
+        sport_type: Sport type identifier (e.g. "Ride", "Run", "Swim"). Defaults to "Ride".
+                   Matches the sport settings grouping in Intervals.icu.
+        ftp: Functional Threshold Power in watts (optional)
+        indoor_ftp: Indoor FTP in watts, typically slightly lower than outdoor FTP (optional)
+        lthr: Lactate Threshold Heart Rate in bpm (optional)
+        max_hr: Maximum Heart Rate in bpm (optional)
+        p_max: Maximum power output in watts (optional)
+        w_prime: W' (Anaerobic Work Capacity) in kJ (optional)
+        athlete_id: The Intervals.icu athlete ID (optional, will use ATHLETE_ID from .env if not provided)
+        api_key: The Intervals.icu API key (optional, will use API_KEY from .env if not provided)
+
+    Returns:
+        Confirmation message with updated values.
+    """
+    athlete_id_to_use, error_msg = resolve_athlete_id(athlete_id, config.athlete_id)
+    if error_msg:
+        return error_msg
+
+    # Build payload with only the fields the caller explicitly set
+    payload: dict[str, Any] = {}
+    if ftp is not None:
+        payload["ftp"] = ftp
+    if indoor_ftp is not None:
+        payload["indoor_ftp"] = indoor_ftp
+    if lthr is not None:
+        payload["lthr"] = lthr
+    if max_hr is not None:
+        payload["max_hr"] = max_hr
+    if p_max is not None:
+        payload["p_max"] = p_max
+    if w_prime is not None:
+        payload["w_prime"] = w_prime
+
+    if not payload:
+        return "Error: No fields to update. Provide at least ftp, indoor_ftp, lthr, max_hr, p_max, or w_prime."
+
+    # The sport-settings/{id} endpoint accepts the sport type name as the id parameter
+    url = f"/athlete/{athlete_id_to_use}/sport-settings/{sport_type}"
+
+    result = await make_intervals_request(
+        url=url,
+        api_key=api_key,
+        data=payload,
+        method="PUT",
+    )
+
+    if isinstance(result, dict) and "error" in result:
+        error_message = result.get("message", "Unknown error")
+        return f"Error updating sport settings: {error_message}"
+
+    if not result or not isinstance(result, dict):
+        return "Error: Unexpected response when updating sport settings."
+
+    updated_fields = list(payload)
+    updated_values = ", ".join(f"{k}={v}" for k, v in payload.items())
+    return (f"Successfully updated {sport_type} sport settings "
+            f"({', '.join(updated_fields)}): {updated_values}")

--- a/src/intervals_mcp_server/tools/wellness.py
+++ b/src/intervals_mcp_server/tools/wellness.py
@@ -1,7 +1,7 @@
 """
 Wellness-related MCP tools for Intervals.icu.
 
-This module contains tools for retrieving athlete wellness data.
+This module contains tools for retrieving and updating athlete wellness data.
 """
 
 from intervals_mcp_server.api.client import make_intervals_request
@@ -69,3 +69,43 @@ async def get_wellness_data(
                 wellness_summary += format_wellness_entry(entry, include_all_fields=include_all_fields) + "\n\n"
 
     return wellness_summary
+
+
+@mcp.tool()
+async def update_wellness_data(
+    date: str,
+    fields: dict,
+    athlete_id: str | None = None,
+    api_key: str | None = None,
+) -> str:
+    """Update wellness data for an athlete on a specific date.
+
+    Uses the Intervals.icu bulk wellness upload endpoint (PUT /athlete/{id}/wellness-bulk).
+    Accepts a date and a dictionary of field name-value pairs to update.
+    Custom fields are referenced by their field code (e.g. "Alcohol", "weight", "restingHR").
+
+    Args:
+        date: The date in YYYY-MM-DD format to update wellness data for.
+        fields: Dictionary of field names to values (e.g. {"weight": 77.5, "Alcohol": 0.0})
+        athlete_id: The Intervals.icu athlete ID (optional, will use ATHLETE_ID from .env if not provided)
+        api_key: The Intervals.icu API key (optional, will use API_KEY from .env if not provided)
+    """
+    athlete_id_to_use, error_msg = resolve_athlete_id(athlete_id, config.athlete_id)
+    if error_msg:
+        return error_msg
+
+    # The bulk wellness endpoint accepts an array of objects, each with an "id" (date) plus fields
+    payload = [{"id": date, **fields}]
+
+    result = await make_intervals_request(
+        url=f"/athlete/{athlete_id_to_use}/wellness-bulk",
+        api_key=api_key,
+        method="PUT",
+        data=payload,
+    )
+
+    if isinstance(result, dict) and "error" in result:
+        return f"Error updating wellness data: {result.get('message')}"
+
+    updated_fields = ", ".join(f"{k}={v}" for k, v in fields.items())
+    return f"Wellness data updated for {date}: {updated_fields}"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -32,6 +32,7 @@ from intervals_mcp_server.server import (  # pylint: disable=wrong-import-positi
     get_activity_intervals,
     get_activity_messages,
     get_activity_streams,
+    update_activity,
     add_or_update_event,
     get_athlete_power_curves,
     get_event_by_id,
@@ -949,3 +950,86 @@ def test_get_activities_resolves_gear_name(monkeypatch):
     assert "Ride 2" in result
     assert "Name: Litening Air" in result
     assert "Name: S-Works Tarmac SL8" in result
+
+
+# ---------------------------------------------------------------------------
+# Update activity (add-or-update PUT)
+# ---------------------------------------------------------------------------
+
+
+def test_update_activity(monkeypatch):
+    """
+    Test update_activity sends a PUT request with the given fields and returns confirmation.
+    """
+    async def fake_put_request(*_args, **kwargs):
+        assert kwargs.get("method") == "PUT"
+        assert kwargs.get("data") == {"name": "Updated Ride", "icu_rpe": 7, "feel": 2}
+        return {"id": "i123", "name": "Updated Ride"}
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_put_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.activities.make_intervals_request", fake_put_request
+    )
+    result = asyncio.run(
+        update_activity(activity_id="i123", name="Updated Ride", icu_rpe=7, feel=2)
+    )
+    assert "Successfully updated activity i123" in result
+    assert "name, icu_rpe, feel" in result
+
+
+def test_update_activity_single_field(monkeypatch):
+    """
+    Test update_activity with a single field only updates that field.
+    """
+    async def fake_put_request(*_args, **kwargs):
+        assert kwargs.get("method") == "PUT"
+        assert kwargs.get("data") == {"icu_rpe": 5}
+        return {"id": "i123"}
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_put_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.activities.make_intervals_request", fake_put_request
+    )
+    result = asyncio.run(update_activity(activity_id="i123", icu_rpe=5))
+    assert "Successfully updated activity i123" in result
+    assert "icu_rpe" in result
+
+
+def test_update_activity_no_fields(monkeypatch):
+    """
+    Test update_activity returns an error when no fields are provided.
+    """
+    result = asyncio.run(update_activity(activity_id="i123"))
+    assert "No fields to update" in result
+
+
+def test_update_activity_error(monkeypatch):
+    """
+    Test update_activity handles API errors gracefully.
+    """
+    async def fake_request(*_args, **_kwargs):
+        return {"error": True, "message": "Activity not found"}
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.activities.make_intervals_request", fake_request
+    )
+    result = asyncio.run(update_activity(activity_id="i999", name="Nope"))
+    assert "Error updating activity" in result
+    assert "Activity not found" in result
+
+
+def test_update_activity_no_id_in_response(monkeypatch):
+    """
+    Test update_activity warns when response has no ID.
+    """
+    async def fake_request(*_args, **_kwargs):
+        return {"name": "Updated"}
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.activities.make_intervals_request", fake_request
+    )
+    result = asyncio.run(update_activity(activity_id="i123", name="Updated"))
+    assert "appears to have been updated" in result
+    assert "verify manually" in result

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -39,6 +39,9 @@ from intervals_mcp_server.server import (  # pylint: disable=wrong-import-positi
     get_events,
     get_gear_list,
     get_wellness_data,
+    update_wellness_data,
+    get_sport_settings,
+    update_sport_settings,
     get_custom_items,
     get_custom_item_by_id,
     create_custom_item,
@@ -1033,3 +1036,147 @@ def test_update_activity_no_id_in_response(monkeypatch):
     result = asyncio.run(update_activity(activity_id="i123", name="Updated"))
     assert "appears to have been updated" in result
     assert "verify manually" in result
+
+
+# ---------------------------------------------------------------------------
+# Sport settings tools
+# ---------------------------------------------------------------------------
+
+
+def test_get_sport_settings(monkeypatch):
+    """Test get_sport_settings returns formatted settings for a matching sport type."""
+    sport_settings_data = [
+        {
+            "types": ["Ride", "VirtualRide"],
+            "ftp": 280,
+            "indoor_ftp": 270,
+            "lthr": 165,
+            "max_hr": 190,
+            "p_max": 850,
+            "w_prime": 20000,
+            "hr_zones": [100, 130, 150, 170, 190],
+            "hr_zone_names": ["Recovery", "Endurance", "Tempo", "Threshold", "VO2max"],
+            "power_zones": [100, 150, 200, 250, 300],
+            "power_zone_names": ["Active Recovery", "Endurance", "Tempo", "Threshold", "VO2max"],
+            "default_gear_id": "b1",
+        }
+    ]
+
+    async def fake_request(*_args, **_kwargs):
+        return sport_settings_data
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.sport_settings.make_intervals_request", fake_request
+    )
+    result = asyncio.run(get_sport_settings(sport_type="Ride", athlete_id="i1"))
+    assert "Sport settings for Ride:" in result
+    assert "FTP (W): 280" in result
+    assert "Indoor FTP (W): 270" in result
+    assert "LTHR (bpm): 165" in result
+    assert "Max HR (bpm): 190" in result
+    assert "HR Zones:" in result
+    assert "Power Zones:" in result
+    assert "Default Gear ID: b1" in result
+
+
+def test_get_sport_settings_no_match(monkeypatch):
+    """Test get_sport_settings returns error when sport type not found."""
+    sport_settings_data = [
+        {"types": ["Ride"], "ftp": 280}
+    ]
+
+    async def fake_request(*_args, **_kwargs):
+        return sport_settings_data
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.sport_settings.make_intervals_request", fake_request
+    )
+    result = asyncio.run(get_sport_settings(sport_type="Run", athlete_id="i1"))
+    assert "No sport settings found for 'Run'" in result
+
+
+def test_update_sport_settings(monkeypatch):
+    """Test update_sport_settings sends PUT with provided fields."""
+    async def fake_put_request(*_args, **kwargs):
+        assert kwargs.get("method") == "PUT"
+        assert kwargs.get("data") == {"ftp": 300, "lthr": 170}
+        return {"types": ["Ride"], "ftp": 300, "lthr": 170}
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_put_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.sport_settings.make_intervals_request", fake_put_request
+    )
+    result = asyncio.run(
+        update_sport_settings(sport_type="Ride", ftp=300, lthr=170, athlete_id="i1")
+    )
+    assert "Successfully updated Ride sport settings" in result
+    assert "ftp" in result
+    assert "lthr" in result
+
+
+def test_update_sport_settings_no_fields(monkeypatch):
+    """Test update_sport_settings returns error when no fields provided."""
+    result = asyncio.run(update_sport_settings(sport_type="Ride", athlete_id="i1"))
+    assert "No fields to update" in result
+
+
+def test_update_sport_settings_error(monkeypatch):
+    """Test update_sport_settings handles API errors."""
+    async def fake_request(*_args, **_kwargs):
+        return {"error": True, "message": "Invalid sport type"}
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.sport_settings.make_intervals_request", fake_request
+    )
+    result = asyncio.run(
+        update_sport_settings(sport_type="Ride", ftp=300, athlete_id="i1")
+    )
+    assert "Error updating sport settings" in result
+    assert "Invalid sport type" in result
+
+
+# ---------------------------------------------------------------------------
+# Wellness update tool
+# ---------------------------------------------------------------------------
+
+
+def test_update_wellness_data(monkeypatch):
+    """Test update_wellness_data sends PUT with correct bulk payload."""
+    async def fake_put_request(*_args, **kwargs):
+        assert kwargs.get("method") == "PUT"
+        payload = kwargs.get("data")
+        assert len(payload) == 1
+        assert payload[0]["id"] == "2024-06-01"
+        assert payload[0]["weight"] == 77.5
+        assert payload[0]["restingHR"] == 55
+        return {}
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_put_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.wellness.make_intervals_request", fake_put_request
+    )
+    result = asyncio.run(
+        update_wellness_data(date="2024-06-01", fields={"weight": 77.5, "restingHR": 55}, athlete_id="i1")
+    )
+    assert "Wellness data updated for 2024-06-01" in result
+    assert "weight=77.5" in result
+    assert "restingHR=55" in result
+
+
+def test_update_wellness_data_error(monkeypatch):
+    """Test update_wellness_data handles API errors."""
+    async def fake_request(*_args, **_kwargs):
+        return {"error": True, "message": "Invalid date"}
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.wellness.make_intervals_request", fake_request
+    )
+    result = asyncio.run(
+        update_wellness_data(date="bad-date", fields={"weight": 77.5}, athlete_id="i1")
+    )
+    assert "Error updating wellness data" in result
+    assert "Invalid date" in result

--- a/uv.lock
+++ b/uv.lock
@@ -352,11 +352,6 @@ dev = [
     { name = "ruff" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "hatch", marker = "extra == 'dev'" },
@@ -371,9 +366,6 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]
 provides-extras = ["dev"]
-
-[package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.1" }]
 
 [[package]]
 name = "jaraco-classes"


### PR DESCRIPTION
New tools:

update_activity — edit post-activity metadata (name, description, RPE, feel, trainer, sport type, gear)
get_sport_settings — retrieve FTP, LTHR, max HR, power/HR zones for a sport type
update_sport_settings — update FTP, LTHR, max HR, Pmax, W' for a sport type
get_gear_list — list gear catalog (bikes, shoes) with stats; resolves gear names on activities
update_wellness_data — write wellness fields (weight, resting HR, custom fields) via bulk endpoint
Changes to existing tools:

get_activities / get_activity_details now resolve gear IDs to human-readable names via /athlete/{id}/gear with module-level caching