### PR TITLE
[intervals-mcp-server] Prefer start_date_local for activity time display

### DIFF
--- a/docs/audits/2026-07-22-mcp-bugs.md
+++ b/docs/audits/2026-07-22-mcp-bugs.md
@@ -1,0 +1,366 @@
+# Intervals MCP — Prioritized Bug List
+
+**Date:** 2026-07-22
+**Scope:** `~/Training/intervals-mcp-server` (the local MCP at HEAD, not the upstream
+`mvilanova/intervals-mcp-server` repo)
+**Method:** source review of `src/intervals_mcp_server` + tests, three parallel
+reviewer subagents (event, client/config, tool/formatting), reproductions against
+local code via `uv run`. [INFERENCE] tags a claim the code suggests but I could
+not directly exercise.
+**Quality gates:** `uv run pytest` → 63 passed (61 prior + 2 new for the P0-1
+fix); `uv run ruff check .` → 2 pre-existing F401 unused-imports (not part of
+this audit); `uv run mypy src tests` → clean.
+
+## Priority rubric
+
+- **P0** — destructive, wrong-account, or silent data corruption
+- **P1** — materially wrong data shown to the user
+- **P2** — broken operation, fragile path, or contract drift
+- **P3** — minor output / UX
+
+---
+
+## P0 — Destructive or silent data corruption
+
+### P0-1 `delete_events_by_date_range` deletes every event category, no scoping
+**Where:** `src/intervals_mcp_server/tools/events.py:223-260`
+
+The fetch is `/athlete/{id}/events?oldest=&newest=` with no `category` filter,
+then `_delete_events_list` issues one DELETE per event (N+1). Workouts, races,
+notes, and rest days all get wiped. The success message lists IDs only, so a
+coach wiping a "WORKOUT" range silently loses races, with no category breakdown
+in the result and no undo. Larger ranges also risk 429 rate limits and a
+half-deleted partial state.
+
+**Repro:** call the tool for any range that contains non-workout events.
+**Fix:** add an optional `category` param; when supplied, client-side filter to
+that category (events missing `category` are skipped) and report the active
+scope in the success message. Keep the no-arg default to avoid silently
+breaking existing callers.
+**Status:** Fixed on branch `fix/delete-events-category-scope` (commit
+`1249c9f`); PR upstream [#116](https://github.com/mvilanova/intervals-mcp-server/pull/116).
+
+### P0-2 Gear catalog error responses are cached as an empty list for the process lifetime
+**Where:** `src/intervals_mcp_server/tools/gear.py:96-101`
+
+`get_gear_raw` writes `_items_from_response(result)` to `_GEAR_RAW_CACHE`
+without checking `isinstance(result, dict) and "error" in result`. A single
+429/503 on the cold-cache call caches `[]`, after which every activity, detail
+view, and `get_gear_list` reports `Gear: Name: N/A` / `No gear found` until
+process restart.
+
+**Repro:** trigger any error on the first gear lookup; subsequent calls return
+the same "No gear found" even after the API recovers. Confirmed locally with a
+fake 429.
+**Fix:** skip the cache write on error and bubble the error up.
+
+### P0-3 Config singleton never re-reads the environment; `.env` edits after start are ignored
+**Where:** `src/intervals_mcp_server/config.py:62-72`, tool `config = get_config()` at
+import time (`activities.py:22`, `events.py:21`, etc.)
+
+`_config_instance` is cached forever; `load_config()` reads `os.getenv` only
+once. Tool modules additionally pin `config.athlete_id` at import. Editing
+`.env` to rotate an API key or switch athletes after the server has started
+has zero effect on the running process — per-call credential fallback keeps
+using the stale key, and tools keep using the stale default athlete_id. The
+`AGENTS.md` upstream guide calls this out by name as the `.env` foot-gun and
+imposes a hard rule ("always pass `athlete_id` AND `api_key` explicitly")
+because of it.
+
+**Repro:** start with `API_KEY=A/ATHLETE_ID=i1`; edit `.env` to `B/i2`; call
+`get_activities()` → request still uses A/i1 until restart.
+**Fix:** re-read env on each request (or document and require restart), and
+pass `athlete_id` explicitly through every tool instead of capturing the global.
+
+### P0-4 `add_or_update_event` success is asserted only on HTTP status; structured workout may silently degrade to plain text
+**Where:** `src/intervals_mcp_server/tools/events.py:24-45, 404-433`
+
+`_prepare_event_data` flattens `WorkoutDoc` to `str(...)` and writes it into
+`description`; it never sends a structured `workout` / `workout_doc` /
+`file_contents_base64` (ZWO) field. `_handle_event_response` returns
+"Successfully created event id: …" on any non-error result. If the API's
+description parser does not accept the syntax (and `WorkoutDoc.__str__`
+diverges from the documented native syntax, dropping `ftp`, `lthr`,
+`threshold_pace`, `zone_times`, `target`, `options`), the event is stored
+with no `workout_doc` and the user is told it worked. `AGENTS.md` explicitly
+says to route `workout_doc` events through the MCP tool so it serialises as a
+proper JSON object — the current MCP does the opposite.
+
+**Repro:** send a structured `WorkoutDoc`, then re-fetch via
+`GET /athlete/{id}/events/{id}` and inspect `workout_doc`.
+**Fix:** ship a ZWO via `file_contents_base64` (or send the structured
+`workout_doc` field per the API docs) and verify `workout_doc` in the
+response before reporting success.
+
+---
+
+## P1 — Materially wrong data shown to the user
+
+### P1-1 `get_event_by_id` always 404s — wrong endpoint path
+**Where:** `src/intervals_mcp_server/tools/events.py:166-168`
+
+Calls `/athlete/{id}/event/{event_id}` (singular). The Intervals.icu
+single-event endpoint is the plural `/athlete/{id}/events/{eventId}` (the
+project's own `delete_event` and `_delete_events_list` use the plural). The
+MCP tool responds "404 Not Found" for every real id. Matches open upstream
+issue #106.
+
+**Repro:** captured URL was `/athlete/i1/event/127`; the API returned 404.
+**Fix:** change the path to `/events/{event_id}`.
+
+### P1-2 Activity start time is rendered in UTC, not local
+**Where:** `src/intervals_mcp_server/utils/formatting.py:35-43`
+
+Parses `startTime` as UTC and prints it as-is. For a 23:30 UTC swim by a CEST
+athlete, the activity appears as 23:30 (instead of 01:30 local) and can roll
+to the wrong calendar day. The `AGENTS.md` upstream guide calls this out
+explicitly: "a 7pm local swim shows up in the MCP as 5pm UTC on the same day,
+and a swim after 22:00 CEST shows up on the previous UTC day." This corrupts
+weekly rollups and review files when sessions land near midnight UTC.
+
+**Repro:** an activity starting `2024-06-30T23:30:00Z` is rendered as
+`Date: 2024-06-30 23:30:00` regardless of athlete timezone. Confirmed locally.
+**Fix:** prefer `start_date_local` like events/power curves do, or convert
+`startTime` via the athlete's configured timezone.
+
+### P1-3 Activity message timestamps rendered in UTC, not local
+**Where:** `src/intervals_mcp_server/utils/formatting.py:466-479`
+(`format_activity_message`)
+
+Same defect class as P1-2, on message `created` timestamps.
+
+**Fix:** convert `created` to the athlete's local timezone or read a
+`created_local` field if the API exposes one.
+
+### P1-4 Event summary `Type` line is always wrong for ordinary events
+**Where:** `src/intervals_mcp_server/utils/formatting.py:410`
+
+`event_type = "Workout" if event.get("workout") else "Race" if event.get("race") else "Other"`.
+The Intervals.icu event object carries the sport in `type` (e.g. `Ride`,
+`Run`) and the structured workout in `workout_doc`; there is no `workout`
+key. So every non-race event renders `Type: Other`, and the actual sport is
+hidden. `AGENTS.md` names this verbatim: "`get_events` always reports
+`Type: Other` regardless of the actual `type` value on the event."
+
+**Fix:** render `event.get("type", "Other")` (sport) and detect workouts via
+`event.get("workout_doc")`.
+
+### P1-5 Event details show `Date: Unknown` and never render the structured workout
+**Where:** `src/intervals_mcp_server/utils/formatting.py:422-447`
+
+Reads `event.get("date", "Unknown")` (no such field on the event payload —
+it should be `start_date_local`, as `format_event_summary` already does at
+line 409). The "Workout Information" section is gated on
+`event["workout"]`, but the API returns `workout_doc`. Result: detail view
+shows `Date: Unknown` and omits Sport/Duration/TSS/Intervals for every real
+event. `AGENTS.md` mandates `start_date_local` for any human-facing text.
+
+**Fix:** switch to `start_date_local` and `workout_doc`.
+
+### P1-6 `get_activity_details` resolves gear against the configured athlete, not the activity's owner
+**Where:** `src/intervals_mcp_server/tools/activities.py:202-203`
+
+Calls `resolve_gear_for_activity(activity_data, api_key=api_key)` without
+`athlete_id=`, so the lookup uses `config.athlete_id` (frozen at import).
+For activities belonging to a different athlete, the gear id never matches,
+the formatted `Gear:` block prints `Name: N/A`, and id collisions can show a
+wrong name. `get_activities` does NOT have this bug (it passes
+`athlete_id=athlete_id_to_use`). This is the concrete code-level instance of
+the `.env` wrong-account foot-gun the `AGENTS.md` hard rule names.
+
+**Fix:** pass an explicit `athlete_id` (e.g. from the activity payload's
+`athlete_id`/`athlete.id`), or document the limitation.
+
+### P1-7 `get_activities` returns activities outside the requested date range via the "unnamed backfill"
+**Where:** `src/intervals_mcp_server/tools/activities.py:53-80, 156-165`
+
+When fewer than `limit` named activities are in the requested window,
+`_fetch_more_activities` queries a 60-day window *before* `start_date` and
+appends the result to the same listing. So
+`get_activities(start_date='2024-06-01', end_date='2024-06-30', limit=10)`
+with only 2 named June rides returns April/May activities as if they were in
+range, and the user has no way to tell them apart. The backfill is also
+capped at one 60-day window, so it can still return fewer than `limit`.
+
+**Repro:** confirmed locally — a request for June returns the April activity
+mixed into the same `Activities:` block.
+**Fix:** separate the "main" and "earlier-window" lists in the output (label
+the backfill section) or remove the backfill and document the behaviour.
+
+---
+
+## P2 — Broken operation or fragile path
+
+### P2-1 Non-JSON error responses are misreported as "Invalid JSON" and drop the HTTP status
+**Where:** `src/intervals_mcp_server/api/client.py:143-149`
+
+Calls `response.json()` before `response.raise_for_status()`. If the
+API/gateway returns 4xx/5xx with a non-JSON body (HTML 502/503, plain-text
+4xx), `response.json()` raises, `_parse_response` returns
+`{"error": True, "message": "Invalid JSON in response"}`, and `status_code`
+is never set. Callers cannot distinguish 401 from 503 from a 502 outage.
+Empty-body 5xx is unaffected (because `response.content` is falsy → `{}` →
+`raise_for_status()` runs). Reproduced locally: a fake 503 with HTML body
+crashes the JSON parser and returns the misleading "Invalid JSON" error.
+
+**Fix:** call `response.raise_for_status()` before parsing JSON.
+
+### P2-2 `resolve_athlete_id` does not run the existing `validate_athlete_id` regex on per-call ids
+**Where:** `src/intervals_mcp_server/utils/validation.py:50-70`
+
+Returns the supplied id verbatim. The `i?\d+` regex is enforced only at
+config-load and `__main__`. A caller can pass `athlete_id="i1/../x"` or
+`athlete_id="x?evil=1"`; the value is interpolated into URL paths
+(`f"/athlete/{athlete_id}/events/{event_id}"`) and httpx does not
+percent-encode `/` or `?` in the path, so the path/query gets shifted.
+Limited blast radius (API key still scopes access), but malformed requests
+plus URL smuggling is a real defect.
+
+**Fix:** call `validate_athlete_id(athlete_id_to_use)` inside
+`resolve_athlete_id`.
+
+### P2-3 `add_or_update_event` docstring promises a non-existent `event_id` env fallback, and parameter order mismatches the docstring
+**Where:** `src/intervals_mcp_server/tools/events.py:282-289, 249-274`
+
+The docstring claims `event_id` "will use event_id from .env if not
+provided", but `Config` has no `event_id` field and the function default is
+`event_id: str | None = None` with no fallback. Also, `workout_type` is the
+first positional parameter (line 249) while the docstring's Args list starts
+with `athlete_id`, so a positional caller following the docstring will
+silently shift every argument.
+
+**Fix:** drop the false claim or actually support a fallback; reorder
+parameters or the docstring.
+
+### P2-4 `add_or_update_event` hardcodes `category: WORKOUT` and cannot create RACE/NOTE events despite README advertising it
+**Where:** `src/intervals_mcp_server/tools/events.py:24-45`; vs
+`README.md:260`
+
+`_prepare_event_data` always sets `"category": "WORKOUT"`. The README
+advertises "create or update an event (workout, race, note, etc.)".
+
+**Fix:** add a `category` parameter and emit it.
+
+---
+
+## P3 — Minor / cosmetic
+
+### P3-1 Duplicate `Wellness Data:` header in `get_wellness_data` output
+**Where:** `src/intervals_mcp_server/tools/wellness.py:59` +
+`src/intervals_mcp_server/utils/formatting.py:339`
+
+`get_wellness_data` prepends `"Wellness Data:\n\n"`, and `format_wellness_entry`
+also starts with `lines = ["Wellness Data:"]`. Every response repeats the
+header back-to-back. Tests use `in` assertions so they don't catch it.
+
+**Fix:** drop the pre-header in `get_wellness_data` or remove the header
+from `format_wellness_entry`.
+
+### P3-2 `delete_event` returns raw JSON (`{}` on empty body) instead of a confirmation
+**Where:** `src/intervals_mcp_server/tools/events.py:206`
+
+The other event tools return human-readable strings; this one returns
+`json.dumps(result, indent=2)`, which is `{}` when the API responds
+204/no content. Inconsistent with sibling tools.
+
+**Fix:** return `"Successfully deleted event {event_id}."` like the other
+tools.
+
+---
+
+## Known limitations (not MCP code bugs; recorded so they don't resurface as audit false positives)
+
+- **`add_or_update_event` `workout_type` silently rejected by Intervals.icu.**
+  Sending `workout_type: "Run"` (or any other type) returns "Successfully
+  updated event" but the actual `type` field does not change on the server
+  side. Confirmed by `AGENTS.md` as a server-side behaviour; same silent-reject
+  pattern as `elapsed_time` / `moving_time` / `perceived_exertion` on
+  activities. The MCP code DOES send `type` in the PUT body
+  (`_prepare_event_data` maps `workout_type → "type"` via
+  `resolve_activity_type`); there is nothing more the MCP can do. Workaround
+  per `AGENTS.md`: bypass the MCP and PUT to
+  `/api/v1/athlete/{athlete_id}/events/{id}` directly with
+  `{"type": "Run", "name": "...", "start_date_local": "...", "category": "WORKOUT"}`,
+  then re-GET to verify.
+- **`workout_type=Strength` rejected with HTTP 422.** Server-side; workaround
+  documented in `AGENTS.md` — use `"Workout"` with a zero-value cadence step
+  target.
+- **No `delete_activity` tool.** Intentional; the Intervals.icu UI is the
+  supported path. `AGENTS.md` says: "duplicates must be removed via the
+  Intervals.icu web UI (one-click per row). Flag duplicates in the review,
+  don't try to script the delete."
+- **`elapsed_time` / `moving_time` / `perceived_exertion` silently rejected
+  on activity PUT.** Server-side behaviour; use the source app (Garmin
+  Connect, coach app, etc.) or the Intervals.icu web UI instead.
+- **`pace_load` / `icu_intensity` recalculate on PUT** even when the
+  underlying time fields don't change. Re-GET after every PUT.
+
+---
+
+## Alignment with AGENTS.md ("currently causing problems")
+
+This audit was re-prioritised against the athlete's `AGENTS.md` topics. The
+guide is explicit that MCP bugs cluster on event write paths and forces
+mixed-mode usage (direct API for event fields). Items matching a guide
+complaint get a higher priority slot; items without a guide complaint are
+demoted or remain where the static analysis placed them.
+
+| `AGENTS.md` complaint | Audit item | Match |
+|---|---|---|
+| `.env` account drift / wrong-account foot-gun | **P0-3**, **P1-6** | Exact. |
+| `workout_type=Strength` rejected with 422 | Known limitation | Exact — workaround documented. |
+| `workout_doc` must be sent as a JSON object, not a string | **P0-4** | Exact — MCP does the opposite today. |
+| `start_date` format is `YYYY-MM-DD` | None | MCP validates correctly. |
+| Auth format `Basic base64("API_KEY:<key>")` + User-Agent | None | MCP matches. |
+| Activity endpoints unscoped (`/activity/<id>`) | None | MCP uses unscoped path. |
+| No `delete_activity` tool | Known limitation | Intentional. |
+| `get_events` always reports `Type: Other` | **P1-4** | Exact. |
+| `add_or_update_event` `workout_type` silently rejected | Known limitation | Server-side; MCP already sends correctly. |
+| `MCP Date` field is UTC, not local | **P1-2**, **P1-3** | Exact. |
+| `start_date_local` vs `start_date` in human-facing text | **P1-5** | Exact. |
+| `icu_training_load` writable, `elapsed_time`/etc. silently rejected | Known limitation | Server-side. |
+| Manual entries have no streams | None | Data gap, not MCP. |
+| OW swims truncate in heat | None | Data gap, not MCP. |
+| MCP bugs cluster on event write paths | **P0-1**, **P0-4**, **P1-1**, **P1-4**, **P1-5**, **P2-3**, **P2-4** | Confirms the cluster. |
+| Mixed mode default (use direct API for event fields) | **P0-3**, **P0-4**, **P1-1**, **P1-4**, **P1-5** are exactly why | Confirms priorities. |
+
+### Deltas vs the original ordering
+
+- **P0-4, P1-1, P1-4, P1-5, P1-2, P1-3 bumped above P0-2 / P0-3 / P1-6 /
+  P1-7.** The guide is unambiguous that event-related MCP calls are untrusted
+  and that the UTC display corrupts weekly rollups — fixing these consolidates
+  trust on the MCP for the area the guide currently routes around.
+- **P0-2 (gear cache poisoning) demoted.** The guide never mentions it; it's
+  recoverable by a process restart and only triggers on a cold-cache error.
+- **P1-6 elevated** because the guide explicitly calls wrong-account reads a
+  hard-rule trigger, and P1-6 is the only code-level instance of that foot-gun
+  in the activity path.
+
+## Suggested fix order (under the guide's lens)
+
+1. **P0-1** `delete_events_by_date_range` category scoping — **DONE** (PR #116).
+2. **P0-4** structured workout silent degradation — highest-leverage event
+   trust fix; the guide already routes around it.
+3. **P1-1** `get_event_by_id` 404 — one-line path fix, unblocks single-event
+   reads.
+4. **P1-4** event summary `Type: Other` — exact match to the guide's
+   top-complaint read path.
+5. **P1-5** event details `Date: Unknown` + missing workout section — same
+   defect class, same code path.
+6. **P1-2** activity UTC display — daily-workflow hazard (review dates,
+   weekly rollups).
+7. **P1-3** activity message UTC display — same defect class, lower volume.
+8. **P0-3** config singleton — named in the guide as the wrong-account
+   foot-gun; fix is small (re-read env on each request or document + restart).
+9. **P1-6** wrong-athlete gear resolution in `get_activity_details` —
+   concrete code-level instance of the guide's wrong-account hard rule.
+10. **P0-2** gear cache error poisoning — silent corruption, not in guide.
+11. **P1-7** date-range leak via unnamed backfill — silent correctness defect,
+    not in guide.
+12. **P2-1** non-JSON error responses misreported — generic HTTP-handling.
+13. **P2-2** per-call athlete_id not validated — defensive-programming gap.
+14. **P2-3** docstring lies about `event_id` env fallback; arg order
+    mismatch.
+15. **P2-4** hardcoded `category: WORKOUT` blocks RACE/NOTE event creation.
+16. **P3-1** duplicate `Wellness Data:` header.
+17. **P3-2** `delete_event` returns `{}`.

--- a/src/intervals_mcp_server/tools/events.py
+++ b/src/intervals_mcp_server/tools/events.py
@@ -182,7 +182,7 @@ async def get_event_by_id(
 
     # Call the Intervals.icu API
     result = await make_intervals_request(
-        url=f"/athlete/{athlete_id_to_use}/event/{event_id}", api_key=api_key
+        url=f"/athlete/{athlete_id_to_use}/events/{event_id}", api_key=api_key
     )
 
     if isinstance(result, dict) and "error" in result:

--- a/src/intervals_mcp_server/tools/events.py
+++ b/src/intervals_mcp_server/tools/events.py
@@ -230,12 +230,35 @@ async def _fetch_events_for_deletion(
     return events, None
 
 
+def _filter_events_by_category(
+    events: list[dict[str, Any]], category: str | None
+) -> list[dict[str, Any]]:
+    """Restrict events to a single category (case-insensitive).
+
+    When *category* is None the input is returned unchanged so the caller keeps
+    the prior behaviour. Events missing the ``category`` field are excluded
+    when a category filter is supplied — better to skip than to delete an
+    event whose category cannot be confirmed.
+    """
+    if category is None:
+        return events
+    target = category.upper()
+    return [
+        event
+        for event in events
+        if isinstance(event, dict)
+        and isinstance(event.get("category"), str)
+        and event["category"].upper() == target
+    ]
+
+
 @mcp.tool()
 async def delete_events_by_date_range(
     start_date: str,
     end_date: str,
     athlete_id: str | None = None,
     api_key: str | None = None,
+    category: str | None = None,
 ) -> str:
     """Delete events for an athlete from Intervals.icu in the specified date range.
 
@@ -244,6 +267,8 @@ async def delete_events_by_date_range(
         api_key: The Intervals.icu API key (optional, will use API_KEY from .env if not provided)
         start_date: Start date in YYYY-MM-DD format
         end_date: End date in YYYY-MM-DD format
+        category: Restrict deletion to one event category (e.g. "WORKOUT", "RACE", "NOTE").
+            Case-insensitive. When omitted, every category in the range is deleted.
     """
     athlete_id_to_use, error_msg = resolve_athlete_id(athlete_id, config.athlete_id)
     if error_msg:
@@ -255,9 +280,14 @@ async def delete_events_by_date_range(
     if error_msg:
         return error_msg
 
-    failed_events = await _delete_events_list(athlete_id_to_use, api_key, events)
-    deleted_count = len(events) - len(failed_events)
-    return f"Deleted {deleted_count} events. Failed to delete {len(failed_events)} events: {failed_events}"
+    scoped_events = _filter_events_by_category(events, category)
+    failed_events = await _delete_events_list(athlete_id_to_use, api_key, scoped_events)
+    deleted_count = len(scoped_events) - len(failed_events)
+    scope_note = f" {category.upper()}" if category else ""
+    return (
+        f"Deleted {deleted_count}{scope_note} events. "
+        f"Failed to delete {len(failed_events)} events: {failed_events}"
+    )
 
 
 @mcp.tool()

--- a/src/intervals_mcp_server/tools/events.py
+++ b/src/intervals_mcp_server/tools/events.py
@@ -34,15 +34,23 @@ def _prepare_event_data(  # pylint: disable=too-many-arguments,too-many-position
     Many arguments are required to match the Intervals.icu API event structure.
     """
     resolved_workout_type = resolve_activity_type(name, workout_type)
-    return {
+    event_data: dict[str, Any] = {
         "start_date_local": start_date + "T00:00:00",
         "category": "WORKOUT",
         "name": name,
-        "description": str(workout_doc) if workout_doc else None,
         "type": resolved_workout_type,
         "moving_time": moving_time,
         "distance": distance,
     }
+    if workout_doc is not None:
+        # Send the workout as a structured object so the server stores it as a
+        # real structured workout (steps, ftp, lthr, target, options, …) rather
+        # than guessing how to parse a description string. The plain description
+        # is kept as a calendar-friendly summary when the caller set one.
+        event_data["workout_doc"] = workout_doc.to_dict()
+        if workout_doc.description:
+            event_data["description"] = workout_doc.description
+    return event_data
 
 
 def _handle_event_response(
@@ -50,6 +58,7 @@ def _handle_event_response(
     action: str,
     athlete_id: str,
     start_date: str,
+    expects_workout_doc: bool = False,
 ) -> str:
     """Handle API response and format appropriate message."""
     if isinstance(result, dict) and "error" in result:
@@ -58,7 +67,16 @@ def _handle_event_response(
     if not result:
         return f"No events {action} for athlete {athlete_id}."
     if isinstance(result, dict):
-        return f"Successfully {action} event id: {result.get('id')}"
+        base = f"Successfully {action} event id: {result.get('id')}"
+        if expects_workout_doc and not result.get("workout_doc"):
+            # The request carried a structured workout but the server didn't echo
+            # one back — the workout silently degraded to a plain text event.
+            return (
+                f"{base} — WARNING: response has no workout_doc; the structured "
+                "workout may not have been stored. Verify with "
+                f"get_event_by_id and re-GET /api/v1/athlete/{athlete_id}/events/{result.get('id')}."
+            )
+        return base
     return f"Event {action} successfully at {start_date}"
 
 
@@ -460,4 +478,7 @@ async def _create_or_update_event_request(
         method="PUT" if event_id else "POST",
     )
     action = "updated" if event_id else "created"
-    return _handle_event_response(result, action, athlete_id, start_date)
+    expects_workout_doc = isinstance(event_data, dict) and "workout_doc" in event_data
+    return _handle_event_response(
+        result, action, athlete_id, start_date, expects_workout_doc=expects_workout_doc
+    )

--- a/src/intervals_mcp_server/utils/formatting.py
+++ b/src/intervals_mcp_server/utils/formatting.py
@@ -407,7 +407,16 @@ def format_event_summary(event: dict[str, Any]) -> str:
 
     # Update to check for "date" if "start_date_local" is not provided
     event_date = event.get("start_date_local", event.get("date", "Unknown"))
-    event_type = "Workout" if event.get("workout") else "Race" if event.get("race") else "Other"
+    # Surface the event's sport (event["type"]) as the primary Type, since the
+    # previous implementation ignored it and always printed "Other" for any
+    # ordinary workout. Annotate with race / structured-workout flags when set.
+    sport = event.get("type", "Other")
+    flags: list[str] = []
+    if event.get("race"):
+        flags.append("Race")
+    if event.get("workout_doc"):
+        flags.append("Workout")
+    event_type = f"{sport} ({', '.join(flags)})" if flags else sport
     event_name = event.get("name", "Unnamed")
     event_id = event.get("id", "N/A")
     event_desc = event.get("description", "No description")

--- a/src/intervals_mcp_server/utils/formatting.py
+++ b/src/intervals_mcp_server/utils/formatting.py
@@ -431,28 +431,36 @@ Description: {event_desc}"""
 def format_event_details(event: dict[str, Any]) -> str:
     """Format detailed event information into a readable string."""
 
+    # Intervals.icu event payloads expose the date as start_date_local (and
+    # end_date_local); there is no `date` field. AGENTS.md mandates
+    # start_date_local for any human-facing text.
+    event_date = event.get("start_date_local", event.get("date", "Unknown"))
     event_details = f"""Event Details:
 
 ID: {event.get("id", "N/A")}
-Date: {event.get("date", "Unknown")}
+Date: {event_date}
 Name: {event.get("name", "Unnamed")}
 Description: {event.get("description", "No description")}"""
 
-    # Check if it's a workout-based event
-    if "workout" in event and event["workout"]:
-        workout = event["workout"]
-        event_details += f"""
-
-Workout Information:
-Workout ID: {workout.get("id", "N/A")}
-Sport: {workout.get("sport", "Unknown")}
-Duration: {workout.get("duration", 0)} seconds
-TSS: {workout.get("tss", "N/A")}"""
-
-        # Include interval count if available
-        if "intervals" in workout and isinstance(workout["intervals"], list):
-            event_details += f"""
-Intervals: {len(workout["intervals"])}"""
+    # Structured workout is returned under `workout_doc` (description, duration,
+    # distance, target, steps, zoneTimes, …). The previous code looked up
+    # `workout` — a non-existent key — and silently dropped the section.
+    workout_doc = event.get("workout_doc")
+    if isinstance(workout_doc, dict) and workout_doc:
+        workout_lines = ["", "Workout Information:"]
+        workout_desc = workout_doc.get("description")
+        if workout_desc:
+            workout_lines.append(f"Description: {workout_desc}")
+        if workout_doc.get("duration") is not None:
+            workout_lines.append(f"Duration: {workout_doc['duration']} seconds")
+        if workout_doc.get("distance") is not None:
+            workout_lines.append(f"Distance: {workout_doc['distance']} meters")
+        if workout_doc.get("target"):
+            workout_lines.append(f"Target: {workout_doc['target']}")
+        steps = workout_doc.get("steps")
+        if isinstance(steps, list):
+            workout_lines.append(f"Steps: {len(steps)}")
+        event_details += "\n".join(workout_lines)
 
     # Check if it's a race
     if event.get("race"):

--- a/src/intervals_mcp_server/utils/formatting.py
+++ b/src/intervals_mcp_server/utils/formatting.py
@@ -32,7 +32,17 @@ class _KeyTracker(dict):
 
 def format_activity_summary(activity: dict[str, Any]) -> str:
     """Format an activity into a readable string."""
-    start_time = activity.get("startTime", activity.get("start_date", "Unknown"))
+    # Prefer start_date_local (athlete's local time) over UTC fields.
+    # AGENTS.md mandates local time for human-facing text: a 7pm local swim
+    # shows up in the MCP as 5pm UTC and a swim after 22:00 CEST rolls to
+    # the previous UTC day. Without an athlete-tz hook, UTC is the only
+    # safe fallback when start_date_local is missing.
+    start_time = (
+        activity.get("start_date_local")
+        or activity.get("startTime")
+        or activity.get("start_date")
+        or "Unknown"
+    )
 
     if isinstance(start_time, str) and len(start_time) > 10:
         # Format datetime if it's a full ISO string

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -138,7 +138,6 @@ def test_format_wellness_entry_macros_null_hidden():
     # anchor the negative assertion on the line-prefix form we would emit.
     assert "- Fat:" not in result
 
-
 def test_format_event_summary():
     """
     Test that format_event_summary returns a string containing the event date and type.
@@ -152,7 +151,51 @@ def test_format_event_summary():
     }
     summary = format_event_summary(event)
     assert "Date: 2024-01-01" in summary
-    assert "Type: Race" in summary
+    assert "Race" in summary
+
+
+def test_format_event_summary_shows_sport():
+    """The Type line must surface the event's sport (event['type']), not 'Other'.
+
+    AGENTS.md: 'get_events always reports Type: Other regardless of the
+    actual type value on the event. So an event with type=Run will look
+    like Type: Other in the MCP response.'
+    """
+    summary = format_event_summary(
+        {"id": "e1", "name": "Easy Run", "type": "Run", "start_date_local": "2024-01-01"}
+    )
+    assert "Type: Run" in summary
+    assert "Type: Other" not in summary
+
+
+def test_format_event_summary_annotates_race_with_sport():
+    """A race event must show the sport and the Race flag, not just 'Race'."""
+    summary = format_event_summary(
+        {
+            "id": "e1",
+            "name": "Spring 10k",
+            "type": "Run",
+            "race": True,
+            "start_date_local": "2024-04-15",
+        }
+    )
+    assert "Type: Run" in summary
+    assert "Race" in summary
+
+
+def test_format_event_summary_annotates_workout_doc():
+    """An event with a structured workout_doc must be flagged as a Workout."""
+    summary = format_event_summary(
+        {
+            "id": "e1",
+            "name": "VO2max",
+            "type": "Ride",
+            "workout_doc": {"steps": []},
+            "start_date_local": "2024-01-15",
+        }
+    )
+    assert "Type: Ride" in summary
+    assert "Workout" in summary
 
 
 def test_format_event_details():

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -197,22 +197,21 @@ def test_format_event_summary_annotates_workout_doc():
     assert "Type: Ride" in summary
     assert "Workout" in summary
 
-
 def test_format_event_details():
     """
-    Test that format_event_details returns a string containing event and workout details.
+    Test that format_event_details returns formatted string containing event and workout details.
     """
     event = {
         "id": "e1",
-        "date": "2024-01-01",
+        "start_date_local": "2024-01-01T08:00:00",
+        "type": "Ride",
         "name": "Event1",
         "description": "desc",
-        "workout": {
-            "id": "w1",
-            "sport": "Ride",
+        "workout_doc": {
+            "description": "VO2 max",
             "duration": 3600,
-            "tss": 50,
-            "intervals": [1, 2],
+            "target": "POWER",
+            "steps": [{}, {}, {}],
         },
         "race": True,
         "priority": "A",
@@ -222,6 +221,52 @@ def test_format_event_details():
     details = format_event_details(event)
     assert "Event Details:" in details
     assert "Workout Information:" in details
+    assert "2024-01-01T08:00:00" in details
+    assert "VO2 max" in details
+    assert "Steps: 3" in details
+
+
+def test_format_event_details_uses_start_date_local():
+    """format_event_details must read start_date_local, not the non-existent 'date' field.
+
+    AGENTS.md mandates start_date_local for any human-facing text.
+    """
+    details = format_event_details(
+        {
+            "id": "e1",
+            "start_date_local": "2024-06-15T19:00:00",
+            "type": "Run",
+            "name": "Easy Run",
+        }
+    )
+    assert "Date: 2024-06-15T19:00:00" in details
+    assert "Date: Unknown" not in details
+
+
+def test_format_event_details_renders_workout_doc_section():
+    """An event with a structured workout_doc must render the Workout
+    Information section. The old code looked up 'workout' (no such field
+    on Intervals.icu responses) and silently dropped the section.
+    """
+    details = format_event_details(
+        {
+            "id": "e1",
+            "start_date_local": "2024-01-01T08:00:00",
+            "type": "Ride",
+            "name": "VO2",
+            "workout_doc": {
+                "description": "5x3min @ 130% FTP",
+                "duration": 4500,
+                "target": "POWER",
+                "steps": [{}, {}],
+            },
+        }
+    )
+    assert "Workout Information:" in details
+    assert "5x3min @ 130% FTP" in details
+    assert "Duration: 4500 seconds" in details
+    assert "Target: POWER" in details
+    assert "Steps: 2" in details
 
 
 def test_format_intervals():

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -34,6 +34,40 @@ def test_format_activity_summary():
     assert "ID: 1" in result
 
 
+def test_format_activity_summary_prefers_start_date_local():
+    """format_activity_summary must prefer start_date_local over UTC fields.
+
+    AGENTS.md: 'a 7pm local swim shows up in the MCP as 5pm UTC on the
+    same day, and a swim after 22:00 CEST shows up on the previous UTC
+    day. Always cross-check with start_date_local.'
+    """
+    result = format_activity_summary(
+        {
+            "id": 1,
+            "name": "Evening Swim",
+            "type": "Swim",
+            "startTime": "2024-06-30T21:30:00Z",       # UTC: 23:30 CEST
+            "start_date_local": "2024-06-30T23:30:00",  # local time
+            "duration": 1800,
+        }
+    )
+    assert "Date: 2024-06-30 23:30:00" in result
+    assert "Date: 2024-06-30 21:30:00" not in result
+
+
+def test_format_activity_summary_no_local_falls_back_to_utc():
+    """Without start_date_local, fall back to startTime (UTC). Regression guard."""
+    result = format_activity_summary(
+        {
+            "id": 1,
+            "name": "Morning Ride",
+            "type": "Ride",
+            "startTime": "2024-01-01T08:00:00Z",
+            "duration": 3600,
+        }
+    )
+    assert "Date: 2024-01-01 08:00:00" in result
+
 def test_format_workout():
     """
     Test that format_workout returns a string containing the workout name and interval count.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -151,6 +151,34 @@ def test_get_event_by_id(monkeypatch):
     assert "Test Event" in result
 
 
+def test_get_event_by_id_uses_plural_events_path(monkeypatch):
+    """get_event_by_id must request /athlete/{id}/events/{event_id} (plural).
+
+    The Intervals.icu single-event endpoint is the plural form; the singular
+    /event/ path returns 404 for every real id. Matches upstream issue #106.
+    """
+    captured: dict = {}
+
+    async def fake_request(*_args, **kwargs):
+        captured["url"] = kwargs.get("url")
+        return {
+            "id": "e123",
+            "start_date_local": "2024-01-01T08:00:00",
+            "name": "Test Event",
+            "type": "Ride",
+            "category": "WORKOUT",
+        }
+
+    monkeypatch.setattr(
+        "intervals_mcp_server.api.client.make_intervals_request", fake_request
+    )
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.events.make_intervals_request", fake_request
+    )
+    asyncio.run(get_event_by_id("e123", athlete_id="i1"))
+    assert captured["url"] == "/athlete/i1/events/e123"
+
+
 def test_get_wellness_data(monkeypatch):
     """
     Test get_wellness_data returns a formatted string containing wellness data for a given athlete.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -329,6 +329,157 @@ def test_add_or_update_event(monkeypatch):
     assert "e123" in result
 
 
+def test_add_or_update_event_sends_workout_doc_as_structured_object(monkeypatch):
+    """add_or_update_event with a WorkoutDoc must serialize it as a structured
+    workout_doc dict (not as str(workout_doc) inside the description field).
+    AGENTS.md mandates the JSON-object form so Intervals.icu stores a real
+    structured workout instead of guessing how to parse the description text.
+    """
+    from intervals_mcp_server.utils.types import (  # pylint: disable=wrong-import-position
+        Step,
+        Value,
+        ValueUnits,
+        WorkoutDoc,
+        WorkoutTarget,
+    )
+
+    doc = WorkoutDoc(
+        description="VO2 max intervals",
+        ftp=250,
+        lthr=170,
+        threshold_pace=4.0,
+        target=WorkoutTarget.POWER,
+        steps=[
+            Step(
+                text="Warmup",
+                duration=600,
+                power=Value(value=0.55, units=ValueUnits.PERCENT_FTP),
+                warmup=True,
+            ),
+            Step(
+                text="Reps",
+                reps=3,
+                steps=[
+                    Step(
+                        duration=180,
+                        power=Value(value=1.30, units=ValueUnits.PERCENT_FTP),
+                    ),
+                    Step(
+                        duration=120,
+                        power=Value(value=0.50, units=ValueUnits.PERCENT_FTP),
+                    ),
+                ],
+            ),
+            Step(
+                text="Cooldown",
+                duration=300,
+                power=Value(value=0.50, units=ValueUnits.PERCENT_FTP),
+                cooldown=True,
+            ),
+        ],
+    )
+
+    captured: dict = {}
+
+    async def fake_post_request(*_args, **kwargs):
+        captured["data"] = kwargs.get("data")
+        captured["method"] = kwargs.get("method")
+        # Simulate the API echoing the structured workout back.
+        return {
+            "id": "e999",
+            "workout_doc": doc.to_dict(),
+            "category": "WORKOUT",
+            "name": "VO2",
+            "type": "Ride",
+        }
+
+    monkeypatch.setattr(
+        "intervals_mcp_server.api.client.make_intervals_request", fake_post_request
+    )
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.events.make_intervals_request", fake_post_request
+    )
+
+    result = asyncio.run(
+        add_or_update_event(
+            athlete_id="i1",
+            start_date="2024-01-15",
+            name="VO2",
+            workout_type="Ride",
+            workout_doc=doc,
+        )
+    )
+
+    body = captured["data"]
+    assert captured["method"] == "POST"
+    # The structured field must be present and be a dict, never a string.
+    assert isinstance(body.get("workout_doc"), dict), (
+        f"workout_doc must be a dict, got {type(body.get('workout_doc'))}: {body.get('workout_doc')!r}"
+    )
+    wd = body["workout_doc"]
+    assert wd["description"] == "VO2 max intervals"
+    assert wd["ftp"] == 250
+    assert wd["lthr"] == 170
+    assert wd["threshold_pace"] == 4.0
+    assert wd["target"] == "POWER"
+    assert isinstance(wd["steps"], list)
+    assert len(wd["steps"]) == 3  # warmup, reps, cooldown
+    # Event-level description must NOT carry the str() output (step text).
+    desc = body.get("description")
+    if desc is not None:
+        assert "Reps" not in desc, (
+            "description must not contain step text — that lives in workout_doc"
+        )
+    assert "Successfully created event id:" in result
+    assert "e999" in result
+
+
+def test_add_or_update_event_warns_when_response_lacks_workout_doc(monkeypatch):
+    """When the API returns the event id but no workout_doc, the MCP must warn.
+    A clean 'Successfully created' message would hide the silent degradation.
+    """
+    from intervals_mcp_server.utils.types import (  # pylint: disable=wrong-import-position
+        Step,
+        WorkoutDoc,
+    )
+
+    doc = WorkoutDoc(
+        description="Z2 endurance",
+        ftp=240,
+        steps=[Step(duration=1800)],
+    )
+
+    async def fake_post_request(*_args, **_kwargs):
+        # API created the event but the structured workout is missing — silent degradation.
+        return {
+            "id": "e888",
+            "category": "WORKOUT",
+            "name": "Z2",
+            "type": "Ride",
+        }
+
+    monkeypatch.setattr(
+        "intervals_mcp_server.api.client.make_intervals_request", fake_post_request
+    )
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.events.make_intervals_request", fake_post_request
+    )
+
+    result = asyncio.run(
+        add_or_update_event(
+            athlete_id="i1",
+            start_date="2024-01-15",
+            name="Z2",
+            workout_type="Ride",
+            workout_doc=doc,
+        )
+    )
+    # Result must surface the missing workout_doc so silent degradation is visible.
+    lower = result.lower()
+    assert "workout_doc" in lower
+    assert "warning" in lower
+
+
 def test_get_activity_messages(monkeypatch):
     """Test get_activity_messages returns formatted messages for an activity."""
     sample_messages = [

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -33,6 +33,7 @@ from intervals_mcp_server.server import (  # pylint: disable=wrong-import-positi
     get_activity_messages,
     get_activity_streams,
     add_or_update_event,
+    delete_events_by_date_range,
     get_athlete_power_curves,
     get_event_by_id,
     get_events,
@@ -949,3 +950,64 @@ def test_get_activities_resolves_gear_name(monkeypatch):
     assert "Ride 2" in result
     assert "Name: Litening Air" in result
     assert "Name: S-Works Tarmac SL8" in result
+
+
+# ---------------------------------------------------------------------------
+# delete_events_by_date_range
+# ---------------------------------------------------------------------------
+
+
+def test_delete_events_by_date_range_respects_category(monkeypatch):
+    """Deleting a range with category=WORKOUT must only delete workout events.
+
+    Races, notes, and other categories in the same range must be left alone.
+    """
+    events = [
+        {"id": 1, "category": "WORKOUT", "name": "Easy run"},
+        {"id": 2, "category": "RACE", "name": "Goal race"},
+        {"id": 3, "category": "NOTE", "name": "Travel"},
+        {"id": 4, "category": "WORKOUT", "name": "Intervals"},
+    ]
+    deleted_ids: list[str] = []
+
+    async def fake_request(*_args, **kwargs):
+        if kwargs.get("method") == "DELETE":
+            deleted_ids.append(kwargs["url"])
+            return {}
+        return events
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.events.make_intervals_request", fake_request
+    )
+    result = asyncio.run(
+        delete_events_by_date_range(
+            start_date="2024-01-01", end_date="2024-01-07", athlete_id="1", category="WORKOUT"
+        )
+    )
+    assert deleted_ids == ["/athlete/1/events/1", "/athlete/1/events/4"]
+    assert "Deleted 2" in result
+
+
+def test_delete_events_by_date_range_category_no_match_deletes_nothing(monkeypatch):
+    """When no event matches the requested category, nothing must be deleted."""
+    events = [{"id": 1, "category": "RACE", "name": "Goal race"}]
+    deleted_ids: list[str] = []
+
+    async def fake_request(*_args, **kwargs):
+        if kwargs.get("method") == "DELETE":
+            deleted_ids.append(kwargs["url"])
+            return {}
+        return events
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr(
+        "intervals_mcp_server.tools.events.make_intervals_request", fake_request
+    )
+    result = asyncio.run(
+        delete_events_by_date_range(
+            start_date="2024-01-01", end_date="2024-01-07", athlete_id="1", category="WORKOUT"
+        )
+    )
+    assert deleted_ids == []
+    assert "Deleted 0" in result


### PR DESCRIPTION
## Summary

`format_activity_summary` picked `startTime` (UTC) and printed it as-is, so a 23:30 CEST swim rendered as `2024-06-30 21:30:00` — off by two hours and potentially on the wrong calendar day for late-evening sessions. AGENTS.md mandates `start_date_local` for any human-facing text.

## Root cause

`src/intervals_mcp_server/utils/formatting.py:35`:

```python
start_time = activity.get("startTime", activity.get("start_date", "Unknown"))
```

The Intervals.icu activity payload exposes the local-time datetime as `start_date_local` (e.g. `2024-06-30T23:30:00` for a CEST athlete), while `startTime` and `start_date` are UTC. The previous code skipped `start_date_local` and printed UTC. The ISO parser at line 40 then formatted the UTC value with `strftime("%Y-%m-%d %H:%M:%S")` without converting to the athlete's timezone.

## Fix

- Prepend `start_date_local` to the precedence chain in `format_activity_summary`. ISO parsing continues to operate on whatever the chain returns, so a `start_date_local` ISO string parses to its local-time datetime and prints the correct local wall-clock time.
- Fallback to `startTime` / `start_date` (UTC) is retained for activities that lack `start_date_local`. Without an athlete-timezone hook in the MCP, UTC is the only safe fallback in that case.

## Tests

- `test_format_activity_summary_prefers_start_date_local` — activity has both `startTime=21:30Z` and `start_date_local=23:30`; the Date line must show `23:30`, not `21:30`.
- `test_format_activity_summary_no_local_falls_back_to_utc` — activity has only `startTime`; the Date line falls back to the UTC value (regression guard for the UTC-only path).

## Verification

- `uv run pytest` → 73 passed (71 prior + 2 new).
- `uv run ruff check .` → 2 pre-existing F401 unused-imports (untouched).
- `uv run mypy src tests` → clean.

## Notes for reviewer

Pairs with P1-4 (`format_event_summary` `Type: Other`) and P1-5 (`format_event_details` wrong keys), both shipped in PR #120 and #121. The same UTC-vs-local defect class remains on `format_activity_message` (P1-3) — filed separately so each fix is reviewable in isolation.