### PR TITLE
fix: pin mcp[cli] to <2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12"
 license = { text = "GPL-3.0-only" }
 authors = [{ name = "Marc Vilanova", email = "barker-riddle.8z@icloud.com" }]
-dependencies = ["mcp[cli]>=1.4.0", "httpx>=0.25.0", "python-dotenv>=1.0.0"]
+dependencies = ["mcp[cli]>=1.4.0,<2.0.0", "httpx>=0.25.0", "python-dotenv>=1.0.0"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",

--- a/uv.lock
+++ b/uv.lock
@@ -352,16 +352,11 @@ dev = [
     { name = "ruff" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "hatch", marker = "extra == 'dev'" },
     { name = "httpx", specifier = ">=0.25.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.4.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.4.0,<2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.5" },
@@ -371,9 +366,6 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]
 provides-extras = ["dev"]
-
-[package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.1" }]
 
 [[package]]
 name = "jaraco-classes"


### PR DESCRIPTION
## Summary
- The `mcp[cli]` dependency in `pyproject.toml` was unbounded above `>=1.4.0`, so a future `mcp` v2 release could pull in breaking changes silently.
- Pins it to `>=1.4.0,<2.0.0` and regenerates `uv.lock` accordingly.

## Test plan
- [x] `uv lock` regenerates cleanly with the new constraint
- [ ] Existing test suite passes (no code changes beyond dependency pin)