### PR TITLE
[intervals-mcp-server] Add indoor flag support to add_or_update_event

### DIFF
--- a/src/intervals_mcp_server/tools/events.py
+++ b/src/intervals_mcp_server/tools/events.py
@@ -28,13 +28,14 @@ def _prepare_event_data(  # pylint: disable=too-many-arguments,too-many-position
     workout_doc: WorkoutDoc | None,
     moving_time: int | None,
     distance: int | None,
+    indoor: bool | None = None,
 ) -> dict[str, Any]:
     """Prepare event data dictionary for API request.
 
     Many arguments are required to match the Intervals.icu API event structure.
     """
     resolved_workout_type = resolve_activity_type(name, workout_type)
-    return {
+    event_data: dict[str, Any] = {
         "start_date_local": start_date + "T00:00:00",
         "category": "WORKOUT",
         "name": name,
@@ -43,6 +44,11 @@ def _prepare_event_data(  # pylint: disable=too-many-arguments,too-many-position
         "moving_time": moving_time,
         "distance": distance,
     }
+    # Omit `indoor` entirely when unset so partial updates don't clear an
+    # existing flag on the event.
+    if indoor is not None:
+        event_data["indoor"] = indoor
+    return event_data
 
 
 def _handle_event_response(
@@ -271,6 +277,7 @@ async def add_or_update_event(  # pylint: disable=too-many-arguments,too-many-po
     workout_doc: WorkoutDoc | None = None,
     moving_time: int | None = None,
     distance: int | None = None,
+    indoor: bool | None = None,
 ) -> str:
     """Post event for an athlete to Intervals.icu this follows the event api from intervals.icu
     If event_id is provided, the event will be updated instead of created.
@@ -287,6 +294,8 @@ async def add_or_update_event(  # pylint: disable=too-many-arguments,too-many-po
         workout_type: Workout type (e.g. Ride, Run, Swim, Walk, Row)
         moving_time: Total expected moving time of the workout in seconds (optional)
         distance: Total expected distance of the workout in meters (optional)
+        indoor: Mark the event as an indoor/trainer session. Optional; omit to leave
+            unchanged when updating an existing event.
 
     Example:
         "workout_doc": {
@@ -347,7 +356,7 @@ async def add_or_update_event(  # pylint: disable=too-many-arguments,too-many-po
     try:
         validated_date = validate_date(start_date)
         event_data = _prepare_event_data(
-            name, workout_type, validated_date, workout_doc, moving_time, distance
+            name, workout_type, validated_date, workout_doc, moving_time, distance, indoor
         )
         return await _create_or_update_event_request(
             athlete_id_to_use, api_key, event_data, validated_date, event_id

--- a/src/intervals_mcp_server/utils/formatting.py
+++ b/src/intervals_mcp_server/utils/formatting.py
@@ -412,11 +412,17 @@ def format_event_summary(event: dict[str, Any]) -> str:
     event_id = event.get("id", "N/A")
     event_desc = event.get("description", "No description")
 
-    return f"""Date: {event_date}
+    summary = f"""Date: {event_date}
 ID: {event_id}
 Type: {event_type}
 Name: {event_name}
 Description: {event_desc}"""
+
+    # Only shown when the event carries the flag; it is null on most events.
+    if event.get("indoor") is not None:
+        summary += f"\nIndoor: {event['indoor']}"
+
+    return summary
 
 
 def format_event_details(event: dict[str, Any]) -> str:
@@ -428,6 +434,11 @@ ID: {event.get("id", "N/A")}
 Date: {event.get("date", "Unknown")}
 Name: {event.get("name", "Unnamed")}
 Description: {event.get("description", "No description")}"""
+
+    # Only shown when the event carries the flag; it is null on most events.
+    if event.get("indoor") is not None:
+        event_details += f"""
+Indoor: {event["indoor"]}"""
 
     # Check if it's a workout-based event
     if "workout" in event and event["workout"]:

--- a/tests/test_events_indoor.py
+++ b/tests/test_events_indoor.py
@@ -1,0 +1,90 @@
+"""
+Tests for the `indoor` flag on add_or_update_event.
+
+The flag maps to the event-level `indoor` boolean on the Intervals.icu events
+API. These tests capture the payload sent to the API to assert that the field
+is included only when the caller sets it, so that partial updates cannot clear
+an existing flag.
+"""
+
+import asyncio
+import os
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+os.environ.setdefault("API_KEY", "test")
+os.environ.setdefault("ATHLETE_ID", "i1")
+
+from intervals_mcp_server.server import (  # pylint: disable=wrong-import-position
+    add_or_update_event,
+)
+
+
+def _capture_event_payload(monkeypatch) -> dict:
+    """Patch make_intervals_request and capture the payload sent to the API."""
+    captured: dict = {}
+
+    async def fake_request(*_args, **kwargs):
+        captured["data"] = kwargs.get("data")
+        captured["method"] = kwargs.get("method")
+        captured["url"] = kwargs.get("url")
+        return {"id": "e123"}
+
+    monkeypatch.setattr("intervals_mcp_server.api.client.make_intervals_request", fake_request)
+    monkeypatch.setattr("intervals_mcp_server.tools.events.make_intervals_request", fake_request)
+    return captured
+
+
+def test_add_or_update_event_sets_indoor_flag(monkeypatch):
+    """indoor=True is sent as a top-level boolean field on the event payload."""
+    captured = _capture_event_payload(monkeypatch)
+
+    asyncio.run(
+        add_or_update_event(
+            athlete_id="i1",
+            start_date="2024-01-15",
+            name="Trainer session",
+            workout_type="Ride",
+            indoor=True,
+        )
+    )
+
+    assert captured["data"]["indoor"] is True
+    assert captured["method"] == "POST"
+
+
+def test_add_or_update_event_clears_indoor_flag(monkeypatch):
+    """indoor=False is sent explicitly so the flag can be cleared."""
+    captured = _capture_event_payload(monkeypatch)
+
+    asyncio.run(
+        add_or_update_event(
+            athlete_id="i1",
+            event_id="e123",
+            start_date="2024-01-15",
+            name="Outdoor ride",
+            workout_type="Ride",
+            indoor=False,
+        )
+    )
+
+    assert captured["data"]["indoor"] is False
+    assert captured["method"] == "PUT"
+
+
+def test_add_or_update_event_omits_indoor_when_unset(monkeypatch):
+    """Omitting indoor leaves the field out of the payload so updates preserve it."""
+    captured = _capture_event_payload(monkeypatch)
+
+    asyncio.run(
+        add_or_update_event(
+            athlete_id="i1",
+            event_id="e123",
+            start_date="2024-01-15",
+            name="Test Workout",
+            workout_type="Ride",
+        )
+    )
+
+    assert "indoor" not in captured["data"]


### PR DESCRIPTION
## Summary

Adds an optional `indoor` parameter to `add_or_update_event`, mapping to the event-level `indoor` boolean on the Intervals.icu events API. Previously the flag could only be set by hand in the web UI after creating an event.

The flag is useful because Intervals.icu filters planned-workout uploads to Garmin by activity type *and* indoor/outdoor, so marking trainer sessions indoor lets you push only those to the device. That is one use of the field rather than its purpose — it is simply an event property.

## Field name verification

The exact JSON key was confirmed empirically rather than assumed. Fetching events over the API shows `indoor` as a top-level, nullable boolean on the event object. Across a 327-event sample it was `true` on 51, `false` on 51, and `null` on the rest, with the `true` values lining up with actual trainer sessions. It is an event property, not part of `workout_doc`.

## Behaviour

- `indoor=True` / `indoor=False` are sent as a top-level boolean on the event payload.
- When the parameter is `None` (the default) the field is **omitted from the payload entirely**, so a partial update cannot clear the flag on an existing event.
- Existing callers that never pass `indoor` are unaffected.

The flag is also surfaced in `format_event_summary` / `format_event_details`, but only when it is non-null, so output for events without the flag is unchanged.

## Testing

Unit tests in `tests/test_events_indoor.py` capture the outgoing payload and assert the field is set, cleared, and omitted appropriately. They are in their own module to keep `test_server.py` under pylint's 1000-line `C0302` limit.

Manual testing against the live Intervals.icu API (throwaway events, since deleted):

| Case | Result |
| --- | --- |
| Create with `indoor=True`, GET back | `indoor` is `true` |
| Update with `indoor` omitted | flag preserved (other fields updated) |
| Update with `indoor=False` | flag cleared |
| Create with `indoor` omitted | event created unflagged |

## Checks

- `uv run --locked pytest` — 64 passed
- `mypy src tests` — clean
- `uv lock --check` — in sync (no dependency changes)
- `pylint --disable=C0301` — no new findings vs. the current `main` baseline
- `ruff check .` — reports 2 pre-existing errors on `main` (unused imports in `server.py` and `power_curves.py`); both are in files this PR does not touch and are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
